### PR TITLE
Fixing mixed configuration directory issues

### DIFF
--- a/elasticsearch/7.5/Dockerfile
+++ b/elasticsearch/7.5/Dockerfile
@@ -9,3 +9,10 @@ RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install org.codelibs:elast
     mkdir /usr/share/elasticsearch/config/dictionary && \
     chown elasticsearch /usr/share/elasticsearch/config/dictionary
 
+ENV ES_PATH_CONF '/var/lib/elasticsearch/config'
+ENV FESS_DICTIONARY_PATH '/var/lib/elasticsearch/config/'
+
+RUN mkdir -p /var/lib/elasticsearch/config && \
+    mv /usr/share/elasticsearch/config /var/lib/elasticsearch/
+
+VOLUME [ "/usr/share/elasticsearch/data" ]


### PR DESCRIPTION
Sometimes analysis is run on /var/lib/elasticsearch/config even when ES config path is set to /usr/share/elasticsearch/config (the default from ES Docker images).
Moving all Elasticsearch configs to /var/lib/elasticsearch/config solved the problem.
Some issues may be fixed with this (they show the same error logs as mine).
#1967
#1662
#1464

VOLUME directive was set to explicit the default ES data location to Docker users.