### PR TITLE
fix(compose): add restart policy

### DIFF
--- a/compose/docker-compose.cluster.yml
+++ b/compose/docker-compose.cluster.yml
@@ -32,6 +32,7 @@ services:
       options:
         max-size: "10m"
         max-file: "5"
+    restart: unless-stopped
 
   es02:
     image: ghcr.io/codelibs/fess-elasticsearch:7.16.2
@@ -63,6 +64,7 @@ services:
       options:
         max-size: "10m"
         max-file: "5"
+    restart: unless-stopped
 
 volumes:
   esdata01:

--- a/compose/docker-compose.kibana.yml
+++ b/compose/docker-compose.kibana.yml
@@ -11,3 +11,4 @@ services:
       - esnet
     depends_on:
       - es01
+    restart: unless-stopped

--- a/compose/docker-compose.minio.yml
+++ b/compose/docker-compose.minio.yml
@@ -20,6 +20,7 @@ services:
     networks:
       - esnet
     command: server /data
+    restart: unless-stopped
 
 volumes:
   minio-data:

--- a/compose/docker-compose.opensearch.yml
+++ b/compose/docker-compose.opensearch.yml
@@ -31,6 +31,7 @@ services:
       options:
         max-size: "10m"
         max-file: "5"
+    restart: unless-stopped
 
 volumes:
   esdata01:

--- a/compose/docker-compose.standalone.yml
+++ b/compose/docker-compose.standalone.yml
@@ -30,6 +30,7 @@ services:
       options:
         max-size: "10m"
         max-file: "5"
+    restart: unless-stopped
 
 volumes:
   esdata01:

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       options:
         max-size: "10m"
         max-file: "5"
+    restart: unless-stopped
 
 networks:
   esnet:


### PR DESCRIPTION
This avoids downtime when the services exit for some reason, e.g. in our case:

```console
$ docker-compose -f docker-compose.yml -f docker-compose.standalone.yml ps
 Name               Command                State     Ports
----------------------------------------------------------
es01     /bin/tini -- /usr/local/bi ...   Exit 143
fess01   /bin/sh -c /usr/share/fess ...   Exit 137
```


Refs:
- https://docs.docker.com/compose/production/
- https://docs.docker.com/config/containers/start-containers-automatically/