### PR TITLE
Add vanilla compose for single-node OpenSearch configuration

### DIFF
--- a/compose/vanilla/README.md
+++ b/compose/vanilla/README.md
@@ -1,0 +1,31 @@
+Docker Compose for Fess with Vanilla OpenSearch
+===============================================
+
+## Overview
+
+This repository provides compose files for running Fess and OpenSearch with Docker Compose.
+
+**Note:** in this “vanilla” configuration, we do *not* install any of the OpenSearch plugins that Fess normally relies on.
+As a result, Fess’s built-in dictionary management features will *not* be available under this setup.
+
+## Usage
+
+### Fess with OpenSearch:
+
+```
+$ docker compose -f compose.yaml -f compose-opensearch2.yaml up -d
+```
+
+### Stop Fess
+
+```
+$ docker compose -f compose.yaml -f compose-opensearch2.yaml down
+```
+
+### Remove Local Volumes
+
+```
+$ docker volume rm compose_search01_data 
+```
+
+

--- a/compose/vanilla/compose-opensearch2.yaml
+++ b/compose/vanilla/compose-opensearch2.yaml
@@ -1,0 +1,39 @@
+services:
+  search01:
+    build:
+      context: ./opensearch
+      dockerfile: Dockerfile
+    container_name: search01
+    environment:
+      - node.name=search01
+      - discovery.seed_hosts=search01
+      - cluster.initial_cluster_manager_nodes=search01
+      - cluster.name=fess-search
+      - bootstrap.memory_lock=true
+      - node.roles=cluster_manager,data,ingest,ml
+      - "OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g"
+      - "DISABLE_INSTALL_DEMO_CONFIG=true"
+      - "DISABLE_SECURITY_PLUGIN=true"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65535
+        hard: 65535
+    volumes:
+      - search01_data:/usr/share/opensearch/data
+    ports:
+      - 9200:9200
+    networks:
+      - search_net
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
+    restart: unless-stopped
+
+volumes:
+  search01_data:
+    driver: local

--- a/compose/vanilla/compose.yaml
+++ b/compose/vanilla/compose.yaml
@@ -1,0 +1,25 @@
+services:
+  fess01:
+    image: ghcr.io/codelibs/fess:14.19.2
+    container_name: fess01
+    environment:
+      - "SEARCH_ENGINE_HTTP_URL=http://search01:9200"
+      - "SEARCH_ENGINE_TYPE=cloud"
+      - "FESS_DICTIONARY_PATH=${FESS_DICTIONARY_PATH:-/usr/share/opensearch/config/dictionary/}"
+      # - "FESS_PLUGINS=fess-webapp-semantic-search:14.19.2 fess-ds-wikipedia:14.19.2"
+    ports:
+      - "8080:8080"
+    networks:
+      - search_net
+    depends_on:
+      - search01
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
+    restart: unless-stopped
+
+networks:
+  search_net:
+    driver: bridge

--- a/compose/vanilla/opensearch/Dockerfile
+++ b/compose/vanilla/opensearch/Dockerfile
@@ -1,0 +1,15 @@
+FROM opensearchproject/opensearch:2.19.2
+
+# Install S3 repository plugin for snapshot support (not bundled by default)
+RUN bin/opensearch-plugin install --batch repository-s3
+
+# Install optional analysis plugins to match AWS Service analyzers
+RUN bin/opensearch-plugin install --batch \
+    analysis-icu \
+    analysis-kuromoji \
+    analysis-nori \
+    analysis-smartcn \
+    analysis-phonetic \
+    analysis-stempel \
+    analysis-ukrainian
+


### PR DESCRIPTION
This pull request introduces a Docker Compose setup for running Fess with a vanilla OpenSearch configuration. The changes include documentation updates, new compose files for Fess and OpenSearch, and a Dockerfile to customize the OpenSearch container. Key updates focus on enabling Fess to work without OpenSearch plugins, configuring services, and adding plugins to OpenSearch.

### Documentation updates:
* [`compose/vanilla/README.md`](diffhunk://#diff-d0460ede6e90a27581b834f1889e27d498caa114cdf170964efda1bb860e838fR1-R31): Added documentation for setting up Fess with vanilla OpenSearch using Docker Compose, including usage instructions and notes on limitations due to the absence of OpenSearch plugins.

### Docker Compose setup:
* [`compose/vanilla/compose-opensearch2.yaml`](diffhunk://#diff-cdc6d9fd3a44a5be9acc4e9d6c713147e03032bacdc15257e5c48a1f97195f5cR1-R39): Defined the OpenSearch service (`search01`) with environment variables, memory limits, logging options, and a local volume for data storage. Also configured the network and restart policy.
* [`compose/vanilla/compose.yaml`](diffhunk://#diff-b679a599a920d35733c2fa4701ee367a64ae0ef526aaf5fdf14ee5460d62c83cR1-R25): Defined the Fess service (`fess01`) with environment variables for connecting to OpenSearch, port mappings, dependency on `search01`, logging options, and network configuration.

### OpenSearch customization:
* [`compose/vanilla/opensearch/Dockerfile`](diffhunk://#diff-54e6d9addf27c4439d4d73d9a9ff73f89ee031af726c7c9f8632f4a01d6be7f7R1-R15): Customized the OpenSearch container by installing the S3 repository plugin for snapshot support and additional analysis plugins to match AWS Service analyzers.