### PR TITLE
Update base image to Ubuntu Noble for Java 21 JRE

### DIFF
--- a/fess/snapshot-noble/Dockerfile
+++ b/fess/snapshot-noble/Dockerfile
@@ -1,5 +1,5 @@
-# Base image with Java 21 JRE on Ubuntu Jammy
-FROM eclipse-temurin:21-jre-jammy
+# Base image with Java 21 JRE on Ubuntu Noble
+FROM eclipse-temurin:21-jre-noble
 
 # Metadata labels for better container management
 LABEL maintainer="CodeLibs" \


### PR DESCRIPTION
This pull request updates the base image in the Dockerfile from eclipse-temurin:21-jre-jammy to eclipse-temurin:21-jre-noble. This change upgrades the underlying OS from Ubuntu 22.04 (Jammy) to Ubuntu 24.04 (Noble), ensuring compatibility with the latest system libraries and improvements.
