### PR TITLE
Update Fess version to 15.2.0-SNAPSHOT in Dockerfiles

### DIFF
--- a/fess/snapshot-al2023/Dockerfile
+++ b/fess/snapshot-al2023/Dockerfile
@@ -14,7 +14,7 @@ LABEL maintainer="CodeLibs" \
 ENV FESS_APP_TYPE=docker
 
 # Set Fess version as a build argument
-ARG FESS_VERSION=15.1.0-SNAPSHOT
+ARG FESS_VERSION=15.2.0-SNAPSHOT
 
 # This ARG is used to bust the cache when needed
 ARG CACHEBUST=1

--- a/fess/snapshot-noble/Dockerfile
+++ b/fess/snapshot-noble/Dockerfile
@@ -14,7 +14,7 @@ LABEL maintainer="CodeLibs" \
 ENV FESS_APP_TYPE=docker
 
 # Set Fess version as a build argument
-ARG FESS_VERSION=15.1.0-SNAPSHOT
+ARG FESS_VERSION=15.2.0-SNAPSHOT
 
 # This ARG is used to bust the cache when needed
 ARG CACHEBUST=1

--- a/fess/snapshot/Dockerfile
+++ b/fess/snapshot/Dockerfile
@@ -14,7 +14,7 @@ LABEL maintainer="CodeLibs" \
 ENV FESS_APP_TYPE=docker
 
 # Set Fess version as a build argument
-ARG FESS_VERSION=15.1.0-SNAPSHOT
+ARG FESS_VERSION=15.2.0-SNAPSHOT
 
 # This ARG is used to bust the cache when needed
 ARG CACHEBUST=1


### PR DESCRIPTION
This update modifies the FESS_VERSION build argument from 15.1.0-SNAPSHOT to 15.2.0-SNAPSHOT across the following Dockerfiles:

- fess/snapshot/Dockerfile
- fess/snapshot-al2023/Dockerfile
- fess/snapshot-noble/Dockerfile

This ensures all snapshot builds are aligned with the latest Fess development version.