### PR TITLE
Add opensearch 3.2

### DIFF
--- a/opensearch/3.2/Dockerfile
+++ b/opensearch/3.2/Dockerfile
@@ -1,0 +1,17 @@
+FROM opensearchproject/opensearch:3.2.0
+
+ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:3.2.0
+ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:3.2.0
+ARG MINHASH_PLUGIN=org.codelibs.opensearch:opensearch-minhash:3.2.0
+ARG CONFIGSYNC_PLUGIN=org.codelibs.opensearch:opensearch-configsync:3.2.0
+
+RUN /usr/share/opensearch/bin/opensearch-plugin remove opensearch-security-analytics && \
+    /usr/share/opensearch/bin/opensearch-plugin remove opensearch-performance-analyzer && \
+    /usr/share/opensearch/bin/opensearch-plugin install $ANALYSIS_FESS_PLUGIN -b  && \
+    /usr/share/opensearch/bin/opensearch-plugin install $ANALYSIS_EXTENSION_PLUGIN -b && \
+    /usr/share/opensearch/bin/opensearch-plugin install $MINHASH_PLUGIN -b && \
+    /usr/share/opensearch/bin/opensearch-plugin install $CONFIGSYNC_PLUGIN -b && \
+    echo 'configsync.config_path: ${FESS_DICTIONARY_PATH}' >> /usr/share/opensearch/config/opensearch.yml && \
+    mkdir /usr/share/opensearch/config/dictionary && \
+    chown opensearch /usr/share/opensearch/config/dictionary
+


### PR DESCRIPTION
This pull request adds a new `Dockerfile` for OpenSearch 3.2, customizing the container to better support Fess-specific plugins and configuration. The main changes focus on installing required plugins and configuring the environment for Fess integration.

**Plugin management and installation:**

* Removes the default `opensearch-security-analytics` and `opensearch-performance-analyzer` plugins to streamline the container for Fess use cases.
* Installs four Fess-related plugins: `opensearch-analysis-fess`, `opensearch-analysis-extension`, `opensearch-minhash`, and `opensearch-configsync`, using build arguments for versioning and flexibility.

**Configuration and environment setup:**

* Adds a configuration line to `opensearch.yml` to set the `configsync.config_path` using the `FESS_DICTIONARY_PATH` environment variable, enabling dictionary-based configuration sync.
* Creates a dedicated `dictionary` directory within the container and sets ownership to the `opensearch` user for proper permissions.