### PR TITLE
chore(opensearch): bump OpenSearch version to 3.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ docker build --build-arg FESS_VERSION=15.5.1 -t my-fess ./fess/15.5/
 **OpenSearch with Fess Plugins:**
 ```bash
 # Build OpenSearch image
-docker build --rm -t ghcr.io/codelibs/fess-opensearch:3.5.0 ./opensearch/3.5/
+docker build --rm -t ghcr.io/codelibs/fess-opensearch:3.6.0 ./opensearch/3.6/
 ```
 
 ### Project Structure
@@ -180,8 +180,8 @@ docker-fess/
 │   ├── 15.4/               # Previous versions
 │   └── snapshot/           # Development builds
 ├── opensearch/             # OpenSearch images with Fess plugins
-│   ├── 3.5/               # Latest OpenSearch
-│   └── 3.4/               # Previous versions
+│   ├── 3.6/               # Latest OpenSearch
+│   └── 3.5/               # Previous versions
 ├── elasticsearch/          # Elasticsearch images (legacy)
 ├── compose/                # Docker Compose configurations
 │   ├── compose.yaml        # Base Fess service
@@ -212,6 +212,7 @@ FESS_JAVA_OPTS="-Dfess.config.index.document.search.index=myapp.search \
 
 | Fess Version | OpenSearch | Elasticsearch | Java | Base Image |
 |--------------|------------|---------------|------|------------|
+| 15.5.1 | 3.6.0 | - | 21 | Alpine/Ubuntu Noble |
 | 15.5.1 | 3.5.0 | - | 21 | Alpine/Ubuntu Noble |
 | 15.2.0 | 3.2.0 | - | 21 | Alpine/Ubuntu Noble |
 | 15.0.0 | 2.15 | 8.10+ | 17 | Alpine |

--- a/compose/compose-opensearch3.yaml
+++ b/compose/compose-opensearch3.yaml
@@ -1,6 +1,6 @@
 services:
   search01:
-    image: ghcr.io/codelibs/fess-opensearch:3.5.0
+    image: ghcr.io/codelibs/fess-opensearch:3.6.0
     container_name: search01
     environment:
       - node.name=search01

--- a/compose/dashboards/Dockerfile
+++ b/compose/dashboards/Dockerfile
@@ -1,3 +1,3 @@
-FROM opensearchproject/opensearch-dashboards:3.5.0
+FROM opensearchproject/opensearch-dashboards:3.6.0
 RUN /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin remove securityDashboards
 COPY --chown=opensearch-dashboards:opensearch-dashboards opensearch_dashboards.yml /usr/share/opensearch-dashboards/config/

--- a/compose/multi-instance/compose.yaml
+++ b/compose/multi-instance/compose.yaml
@@ -1,6 +1,6 @@
 services:
   search01:
-    image: ghcr.io/codelibs/fess-opensearch:3.5.0
+    image: ghcr.io/codelibs/fess-opensearch:3.6.0
     container_name: search01
     environment:
       - node.name=search01

--- a/compose/snapshot/compose-cluster.yaml
+++ b/compose/snapshot/compose-cluster.yaml
@@ -1,6 +1,6 @@
 services:
   search01:
-    image: ghcr.io/codelibs/fess-opensearch:3.5.0
+    image: ghcr.io/codelibs/fess-opensearch:3.6.0
     container_name: search01
     environment:
       - node.name=search01
@@ -35,7 +35,7 @@ services:
     restart: unless-stopped
 
   search02:
-    image: ghcr.io/codelibs/fess-opensearch:3.5.0
+    image: ghcr.io/codelibs/fess-opensearch:3.6.0
     container_name: search02
     environment:
       - node.name=search02
@@ -72,7 +72,7 @@ services:
       - search01
 
   search03:
-    image: ghcr.io/codelibs/fess-opensearch:3.5.0
+    image: ghcr.io/codelibs/fess-opensearch:3.6.0
     container_name: search03
     environment:
       - node.name=search03
@@ -110,7 +110,7 @@ services:
       - search02
 
   search04:
-    image: ghcr.io/codelibs/fess-opensearch:3.5.0
+    image: ghcr.io/codelibs/fess-opensearch:3.6.0
     container_name: search04
     environment:
       - node.name=search04
@@ -149,7 +149,7 @@ services:
       - search03
 
   search05:
-    image: ghcr.io/codelibs/fess-opensearch:3.5.0
+    image: ghcr.io/codelibs/fess-opensearch:3.6.0
     container_name: search05
     environment:
       - node.name=search05

--- a/opensearch/3.6/Dockerfile
+++ b/opensearch/3.6/Dockerfile
@@ -1,0 +1,31 @@
+FROM opensearchproject/opensearch:3.6.0
+
+# Metadata labels for better container management
+LABEL maintainer="CodeLibs" \
+      org.opencontainers.image.title="Fess OpenSearch" \
+      org.opencontainers.image.description="OpenSearch customized for Fess with required plugins" \
+      org.opencontainers.image.url="https://fess.codelibs.org/" \
+      org.opencontainers.image.source="https://github.com/codelibs/docker-fess" \
+      org.opencontainers.image.vendor="CodeLibs" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:3.6.0
+ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:3.6.0
+ARG MINHASH_PLUGIN=org.codelibs.opensearch:opensearch-minhash:3.6.0
+ARG CONFIGSYNC_PLUGIN=org.codelibs.opensearch:opensearch-configsync:3.6.0
+
+# Remove unnecessary plugins and install Fess-specific plugins
+RUN /usr/share/opensearch/bin/opensearch-plugin remove opensearch-security-analytics && \
+    /usr/share/opensearch/bin/opensearch-plugin remove opensearch-performance-analyzer && \
+    /usr/share/opensearch/bin/opensearch-plugin install $ANALYSIS_FESS_PLUGIN -b  && \
+    /usr/share/opensearch/bin/opensearch-plugin install $ANALYSIS_EXTENSION_PLUGIN -b && \
+    /usr/share/opensearch/bin/opensearch-plugin install $MINHASH_PLUGIN -b && \
+    /usr/share/opensearch/bin/opensearch-plugin install $CONFIGSYNC_PLUGIN -b && \
+    echo 'configsync.config_path: ${FESS_DICTIONARY_PATH}' >> /usr/share/opensearch/config/opensearch.yml && \
+    mkdir /usr/share/opensearch/config/dictionary && \
+    chown opensearch /usr/share/opensearch/config/dictionary
+
+# Add health check to monitor OpenSearch health
+HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=3 \
+    CMD curl -f http://localhost:9200/_cluster/health || exit 1
+


### PR DESCRIPTION
## Summary
- Bump OpenSearch version from 3.5.0 to 3.6.0 across all Docker and compose configurations

## Changes Made
- Add new `opensearch/3.6/Dockerfile` with Fess plugins (analysis-fess, analysis-extension, minhash, configsync)
- Update OpenSearch image tags to 3.6.0 in all compose files (compose-opensearch3, multi-instance, snapshot cluster)
- Update OpenSearch Dashboards base image to 3.6.0
- Update README.md with new version references and compatibility table entry

## Testing
- Build the OpenSearch image: `docker build --rm -t ghcr.io/codelibs/fess-opensearch:3.6.0 ./opensearch/3.6/`
- Start services with `docker compose -f compose/compose-opensearch3.yaml up` and verify cluster health

## Breaking Changes
- None