### PR TITLE
fix(fess): update health check endpoint to /api/v2/health

### DIFF
--- a/fess/snapshot-al2023/Dockerfile
+++ b/fess/snapshot-al2023/Dockerfile
@@ -64,7 +64,7 @@ RUN chmod +x /usr/share/fess/run.sh
 
 # Add health check to monitor container health
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
-    CMD curl -f http://localhost:8080/api/v1/health || exit 1
+    CMD curl -f http://localhost:8080/api/v2/health || exit 1
 
 # The entrypoint script `run.sh` performs setup tasks that require root.
 # Therefore, the container must be started as root.

--- a/fess/snapshot-al2023/run.sh
+++ b/fess/snapshot-al2023/run.sh
@@ -135,9 +135,9 @@ start_fess() {
 
 wait_app() {
   if [[ "x${FESS_CONTEXT_PATH}" = "x" ]] ; then
-    ping_path=/api/v1/health
+    ping_path=/api/v2/health
   else
-    ping_path=${FESS_CONTEXT_PATH}/api/v1/health
+    ping_path=${FESS_CONTEXT_PATH}/api/v2/health
   fi
   while true ; do
     status=$(curl -w '%{http_code}\n' -s -o /dev/null "http://localhost:8080${ping_path}")

--- a/fess/snapshot-noble/Dockerfile
+++ b/fess/snapshot-noble/Dockerfile
@@ -68,7 +68,7 @@ RUN chmod +x /usr/share/fess/run.sh
 
 # Add health check to monitor container health
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
-    CMD curl -f http://localhost:8080/api/v1/health || exit 1
+    CMD curl -f http://localhost:8080/api/v2/health || exit 1
 
 # The entrypoint script `run.sh` performs setup tasks that require root.
 # Therefore, the container must be started as root.

--- a/fess/snapshot-noble/run.sh
+++ b/fess/snapshot-noble/run.sh
@@ -134,9 +134,9 @@ start_fess() {
 
 wait_app() {
   if [[ "x${FESS_CONTEXT_PATH}" = "x" ]] ; then
-    ping_path=/api/v1/health
+    ping_path=/api/v2/health
   else
-    ping_path=${FESS_CONTEXT_PATH}/api/v1/health
+    ping_path=${FESS_CONTEXT_PATH}/api/v2/health
   fi
   while true ; do
     status=$(curl -w '%{http_code}\n' -s -o /dev/null "http://localhost:8080${ping_path}")

--- a/fess/snapshot/Dockerfile
+++ b/fess/snapshot/Dockerfile
@@ -84,7 +84,7 @@ RUN chmod +x /usr/share/fess/run.sh
 
 # Add health check to monitor container health
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
-    CMD curl -f http://localhost:8080/api/v1/health || exit 1
+    CMD curl -f http://localhost:8080/api/v2/health || exit 1
 
 # The entrypoint script `run.sh` performs setup tasks that require root.
 # Therefore, the container must be started as root.

--- a/fess/snapshot/run.sh
+++ b/fess/snapshot/run.sh
@@ -135,9 +135,9 @@ start_fess() {
 
 wait_app() {
   if [[ "x${FESS_CONTEXT_PATH}" = "x" ]] ; then
-    ping_path=/api/v1/health
+    ping_path=/api/v2/health
   else
-    ping_path=${FESS_CONTEXT_PATH}/api/v1/health
+    ping_path=${FESS_CONTEXT_PATH}/api/v2/health
   fi
   while true ; do
     status=$(curl -w '%{http_code}\n' -s -o /dev/null "http://localhost:8080${ping_path}")


### PR DESCRIPTION
## Summary
Updates the container health check from the removed `/api/v1/health` endpoint to `/api/v2/health` across all snapshot image variants.

## Changes Made
- `fess/snapshot/Dockerfile`, `fess/snapshot-al2023/Dockerfile`, `fess/snapshot-noble/Dockerfile`: point the `HEALTHCHECK` curl at `/api/v2/health`.
- `fess/snapshot/run.sh`, `fess/snapshot-al2023/run.sh`, `fess/snapshot-noble/run.sh`: update the `wait_app` ping path (both the default and `FESS_CONTEXT_PATH`-prefixed cases) to `/api/v2/health`.

## Testing
- Diff verified to be limited to the v1 → v2 endpoint change (9 insertions / 9 deletions, no behavioral changes elsewhere).
- Functional validation happens when the snapshot images are built and the container reports healthy via the new endpoint.

## Breaking Changes
- None for image consumers. This aligns the health check with the current Fess API; the old `/api/v1/health` path is no longer served.

## Additional Notes
- Scope is intentionally limited to the snapshot images. Let me know if the released image variants need the same change.