### PR TITLE
chore(fess): bump snapshot Fess version to 15.7.0-SNAPSHOT

### DIFF
--- a/fess/snapshot-al2023/Dockerfile
+++ b/fess/snapshot-al2023/Dockerfile
@@ -14,7 +14,7 @@ LABEL maintainer="CodeLibs" \
 ENV FESS_APP_TYPE=docker
 
 # Set Fess version as a build argument
-ARG FESS_VERSION=15.6.0-SNAPSHOT
+ARG FESS_VERSION=15.7.0-SNAPSHOT
 
 # This ARG is used to bust the cache when needed
 ARG CACHEBUST=1

--- a/fess/snapshot-noble/Dockerfile
+++ b/fess/snapshot-noble/Dockerfile
@@ -14,7 +14,7 @@ LABEL maintainer="CodeLibs" \
 ENV FESS_APP_TYPE=docker
 
 # Set Fess version as a build argument
-ARG FESS_VERSION=15.6.0-SNAPSHOT
+ARG FESS_VERSION=15.7.0-SNAPSHOT
 
 # This ARG is used to bust the cache when needed
 ARG CACHEBUST=1

--- a/fess/snapshot/Dockerfile
+++ b/fess/snapshot/Dockerfile
@@ -14,7 +14,7 @@ LABEL maintainer="CodeLibs" \
 ENV FESS_APP_TYPE=docker
 
 # Set Fess version as a build argument
-ARG FESS_VERSION=15.6.0-SNAPSHOT
+ARG FESS_VERSION=15.7.0-SNAPSHOT
 
 # This ARG is used to bust the cache when needed
 ARG CACHEBUST=1


### PR DESCRIPTION
## Summary
Bump the Fess snapshot build version from `15.6.0-SNAPSHOT` to `15.7.0-SNAPSHOT` across all snapshot image variants.

## Changes Made
- Updated `ARG FESS_VERSION` to `15.7.0-SNAPSHOT` in:
  - `fess/snapshot/Dockerfile`
  - `fess/snapshot-al2023/Dockerfile`
  - `fess/snapshot-noble/Dockerfile`

## Testing
- N/A (build-time version argument change only). Snapshot images will pull the new SNAPSHOT version on the next build.

## Breaking Changes
- None.

## Additional Notes
- This tracks the upstream Fess development line moving to 15.7.0-SNAPSHOT.