### PR TITLE
Pull OpenSearch images from ECR Public registry

### DIFF
--- a/compose/dashboards/Dockerfile
+++ b/compose/dashboards/Dockerfile
@@ -1,3 +1,3 @@
-FROM opensearchproject/opensearch-dashboards:3.6.0
+FROM public.ecr.aws/opensearchproject/opensearch-dashboards:3.6.0
 RUN /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin remove securityDashboards
 COPY --chown=opensearch-dashboards:opensearch-dashboards opensearch_dashboards.yml /usr/share/opensearch-dashboards/config/

--- a/compose/vanilla/opensearch/Dockerfile
+++ b/compose/vanilla/opensearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:3.1.0
+FROM public.ecr.aws/opensearchproject/opensearch:3.1.0
 
 # Install S3 repository plugin for snapshot support (not bundled by default)
 RUN bin/opensearch-plugin install --batch repository-s3

--- a/opensearch/1.1/Dockerfile
+++ b/opensearch/1.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:1.1.0
+FROM public.ecr.aws/opensearchproject/opensearch:1.1.0
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:1.1.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:1.1.0

--- a/opensearch/1.2/Dockerfile
+++ b/opensearch/1.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:1.2.4
+FROM public.ecr.aws/opensearchproject/opensearch:1.2.4
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:1.2.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:1.2.0

--- a/opensearch/1.3/Dockerfile
+++ b/opensearch/1.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:1.3.20
+FROM public.ecr.aws/opensearchproject/opensearch:1.3.20
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:1.3.1
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:1.3.0

--- a/opensearch/2.0/Dockerfile
+++ b/opensearch/2.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.0.1
+FROM public.ecr.aws/opensearchproject/opensearch:2.0.1
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.0.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.0.0

--- a/opensearch/2.1/Dockerfile
+++ b/opensearch/2.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.1.0
+FROM public.ecr.aws/opensearchproject/opensearch:2.1.0
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.1.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.1.0

--- a/opensearch/2.10/Dockerfile
+++ b/opensearch/2.10/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.10.0
+FROM public.ecr.aws/opensearchproject/opensearch:2.10.0
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.10.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.10.0

--- a/opensearch/2.11/Dockerfile
+++ b/opensearch/2.11/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.11.1
+FROM public.ecr.aws/opensearchproject/opensearch:2.11.1
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.11.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.11.0

--- a/opensearch/2.12/Dockerfile
+++ b/opensearch/2.12/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.12.0
+FROM public.ecr.aws/opensearchproject/opensearch:2.12.0
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.12.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.12.0

--- a/opensearch/2.13/Dockerfile
+++ b/opensearch/2.13/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.13.0
+FROM public.ecr.aws/opensearchproject/opensearch:2.13.0
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.13.1
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.13.1

--- a/opensearch/2.14/Dockerfile
+++ b/opensearch/2.14/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.14.0
+FROM public.ecr.aws/opensearchproject/opensearch:2.14.0
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.14.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.14.0

--- a/opensearch/2.15/Dockerfile
+++ b/opensearch/2.15/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.15.0
+FROM public.ecr.aws/opensearchproject/opensearch:2.15.0
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.15.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.15.0

--- a/opensearch/2.16/Dockerfile
+++ b/opensearch/2.16/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.16.0
+FROM public.ecr.aws/opensearchproject/opensearch:2.16.0
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.16.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.16.0

--- a/opensearch/2.17/Dockerfile
+++ b/opensearch/2.17/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.17.1
+FROM public.ecr.aws/opensearchproject/opensearch:2.17.1
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.17.1
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.17.1

--- a/opensearch/2.18/Dockerfile
+++ b/opensearch/2.18/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.18.0
+FROM public.ecr.aws/opensearchproject/opensearch:2.18.0
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.18.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.18.0

--- a/opensearch/2.19/Dockerfile
+++ b/opensearch/2.19/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.19.1
+FROM public.ecr.aws/opensearchproject/opensearch:2.19.1
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.19.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.19.0

--- a/opensearch/2.2/Dockerfile
+++ b/opensearch/2.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.2.1
+FROM public.ecr.aws/opensearchproject/opensearch:2.2.1
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.2.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.2.0

--- a/opensearch/2.3/Dockerfile
+++ b/opensearch/2.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.3.0
+FROM public.ecr.aws/opensearchproject/opensearch:2.3.0
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.3.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.3.0

--- a/opensearch/2.4/Dockerfile
+++ b/opensearch/2.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.4.1
+FROM public.ecr.aws/opensearchproject/opensearch:2.4.1
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.4.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.4.0

--- a/opensearch/2.5/Dockerfile
+++ b/opensearch/2.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.5.0
+FROM public.ecr.aws/opensearchproject/opensearch:2.5.0
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.5.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.5.0

--- a/opensearch/2.6/Dockerfile
+++ b/opensearch/2.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.6.0
+FROM public.ecr.aws/opensearchproject/opensearch:2.6.0
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.6.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.6.0

--- a/opensearch/2.7/Dockerfile
+++ b/opensearch/2.7/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.7.0
+FROM public.ecr.aws/opensearchproject/opensearch:2.7.0
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.7.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.7.0

--- a/opensearch/2.8/Dockerfile
+++ b/opensearch/2.8/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.8.0
+FROM public.ecr.aws/opensearchproject/opensearch:2.8.0
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.8.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.8.0

--- a/opensearch/2.9/Dockerfile
+++ b/opensearch/2.9/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:2.9.0
+FROM public.ecr.aws/opensearchproject/opensearch:2.9.0
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:2.9.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:2.9.0

--- a/opensearch/3.0/Dockerfile
+++ b/opensearch/3.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:3.0.0
+FROM public.ecr.aws/opensearchproject/opensearch:3.0.0
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:3.0.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:3.0.0

--- a/opensearch/3.1/Dockerfile
+++ b/opensearch/3.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:3.1.0
+FROM public.ecr.aws/opensearchproject/opensearch:3.1.0
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:3.1.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:3.1.0

--- a/opensearch/3.2/Dockerfile
+++ b/opensearch/3.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:3.2.0
+FROM public.ecr.aws/opensearchproject/opensearch:3.2.0
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:3.2.0
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:3.2.0

--- a/opensearch/3.3/Dockerfile
+++ b/opensearch/3.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:3.3.2
+FROM public.ecr.aws/opensearchproject/opensearch:3.3.2
 
 # Metadata labels for better container management
 LABEL maintainer="CodeLibs" \

--- a/opensearch/3.4/Dockerfile
+++ b/opensearch/3.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:3.4.0
+FROM public.ecr.aws/opensearchproject/opensearch:3.4.0
 
 # Metadata labels for better container management
 LABEL maintainer="CodeLibs" \

--- a/opensearch/3.5/Dockerfile
+++ b/opensearch/3.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:3.5.0
+FROM public.ecr.aws/opensearchproject/opensearch:3.5.0
 
 # Metadata labels for better container management
 LABEL maintainer="CodeLibs" \

--- a/opensearch/3.6/Dockerfile
+++ b/opensearch/3.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:3.6.0
+FROM public.ecr.aws/opensearchproject/opensearch:3.6.0
 
 # Metadata labels for better container management
 LABEL maintainer="CodeLibs" \

--- a/opensearch/snapshot/Dockerfile
+++ b/opensearch/snapshot/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensearchproject/opensearch:3.3.2
+FROM public.ecr.aws/opensearchproject/opensearch:3.3.2
 
 ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:3.3.1
 ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:3.3.1


### PR DESCRIPTION
## Summary

Switch the base image source from Docker Hub to the ECR Public registry for all OpenSearch and OpenSearch Dashboards images.

- `opensearchproject/opensearch` → `public.ecr.aws/opensearchproject/opensearch`
- `opensearchproject/opensearch-dashboards` → `public.ecr.aws/opensearchproject/opensearch-dashboards`

Image tags/versions are unchanged; only the registry prefix is added.

## Why

Pulling from `public.ecr.aws` avoids Docker Hub anonymous pull rate limits and improves build/pull reliability.

## Scope

- `opensearch/*/Dockerfile` (all versions, including `snapshot`)
- `compose/dashboards/Dockerfile`
- `compose/vanilla/opensearch/Dockerfile`