### PR TITLE
feat(opensearch): add Dockerfile for OpenSearch 3.7.0

### DIFF
--- a/opensearch/3.7/Dockerfile
+++ b/opensearch/3.7/Dockerfile
@@ -1,0 +1,31 @@
+FROM public.ecr.aws/opensearchproject/opensearch:3.7.0
+
+# Metadata labels for better container management
+LABEL maintainer="CodeLibs" \
+      org.opencontainers.image.title="Fess OpenSearch" \
+      org.opencontainers.image.description="OpenSearch customized for Fess with required plugins" \
+      org.opencontainers.image.url="https://fess.codelibs.org/" \
+      org.opencontainers.image.source="https://github.com/codelibs/docker-fess" \
+      org.opencontainers.image.vendor="CodeLibs" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:3.7.0
+ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:3.7.0
+ARG MINHASH_PLUGIN=org.codelibs.opensearch:opensearch-minhash:3.7.0
+ARG CONFIGSYNC_PLUGIN=org.codelibs.opensearch:opensearch-configsync:3.7.0
+
+# Remove unnecessary plugins and install Fess-specific plugins
+RUN /usr/share/opensearch/bin/opensearch-plugin remove opensearch-security-analytics && \
+    /usr/share/opensearch/bin/opensearch-plugin remove opensearch-performance-analyzer && \
+    /usr/share/opensearch/bin/opensearch-plugin install $ANALYSIS_FESS_PLUGIN -b  && \
+    /usr/share/opensearch/bin/opensearch-plugin install $ANALYSIS_EXTENSION_PLUGIN -b && \
+    /usr/share/opensearch/bin/opensearch-plugin install $MINHASH_PLUGIN -b && \
+    /usr/share/opensearch/bin/opensearch-plugin install $CONFIGSYNC_PLUGIN -b && \
+    echo 'configsync.config_path: ${FESS_DICTIONARY_PATH}' >> /usr/share/opensearch/config/opensearch.yml && \
+    mkdir /usr/share/opensearch/config/dictionary && \
+    chown opensearch /usr/share/opensearch/config/dictionary
+
+# Add health check to monitor OpenSearch health
+HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=3 \
+    CMD curl -f http://localhost:9200/_cluster/health || exit 1
+


### PR DESCRIPTION
## Summary

Adds support for OpenSearch 3.7.0 by introducing a new Dockerfile that installs Fess-specific plugins and applies the standard Fess configuration.

## Changes Made

- Added `opensearch/3.7/Dockerfile` based on `public.ecr.aws/opensearchproject/opensearch:3.7.0` (ECR Public registry, consistent with recent 3.x images)
- Installs four Fess plugins: `opensearch-analysis-extension`, `opensearch-analysis-fess`, `opensearch-minhash`, `opensearch-configsync` (all at version 3.7.0)
- Removes unused bundled plugins (`opensearch-security-analytics`, `opensearch-performance-analyzer`) to reduce image size
- Configures `configsync.config_path` in `opensearch.yml` and creates the dictionary directory
- Adds a `HEALTHCHECK` for container health monitoring
- Includes OCI-standard `LABEL` metadata

## Testing

- Dockerfile follows the same structure as the existing `opensearch/3.6/Dockerfile`
- Plugin versions aligned with the OpenSearch 3.7.0 release

## Breaking Changes

None — this is an additive change introducing a new version directory.

## Additional Notes

- Compose files and build scripts for 3.7 can be added in follow-up PRs once this image is validated