### PR TITLE
chore(fess): bump snapshot Fess version to 15.8.0-SNAPSHOT

### DIFF
--- a/fess/snapshot-al2023/Dockerfile
+++ b/fess/snapshot-al2023/Dockerfile
@@ -14,7 +14,7 @@ LABEL maintainer="CodeLibs" \
 ENV FESS_APP_TYPE=docker
 
 # Set Fess version as a build argument
-ARG FESS_VERSION=15.7.0-SNAPSHOT
+ARG FESS_VERSION=15.8.0-SNAPSHOT
 
 # This ARG is used to bust the cache when needed
 ARG CACHEBUST=1

--- a/fess/snapshot-noble/Dockerfile
+++ b/fess/snapshot-noble/Dockerfile
@@ -14,7 +14,7 @@ LABEL maintainer="CodeLibs" \
 ENV FESS_APP_TYPE=docker
 
 # Set Fess version as a build argument
-ARG FESS_VERSION=15.7.0-SNAPSHOT
+ARG FESS_VERSION=15.8.0-SNAPSHOT
 
 # This ARG is used to bust the cache when needed
 ARG CACHEBUST=1

--- a/fess/snapshot/Dockerfile
+++ b/fess/snapshot/Dockerfile
@@ -14,7 +14,7 @@ LABEL maintainer="CodeLibs" \
 ENV FESS_APP_TYPE=docker
 
 # Set Fess version as a build argument
-ARG FESS_VERSION=15.7.0-SNAPSHOT
+ARG FESS_VERSION=15.8.0-SNAPSHOT
 
 # This ARG is used to bust the cache when needed
 ARG CACHEBUST=1


### PR DESCRIPTION
## Summary

Bumps the Fess snapshot version from 15.7.0-SNAPSHOT to 15.8.0-SNAPSHOT across all snapshot Dockerfile variants.

## Changes Made

- Updated `ARG FESS_VERSION` from `15.7.0-SNAPSHOT` to `15.8.0-SNAPSHOT` in:
  - `fess/snapshot/Dockerfile`
  - `fess/snapshot-noble/Dockerfile`
  - `fess/snapshot-al2023/Dockerfile`

## Additional Notes

- This aligns all three snapshot image variants (Ubuntu, Ubuntu Noble, Amazon Linux 2023) with the upcoming 15.8.0 development cycle.