### PR TITLE
feat(opensearch): add Dockerfile for OpenSearch 3.8.0

### DIFF
--- a/opensearch/3.8/Dockerfile
+++ b/opensearch/3.8/Dockerfile
@@ -9,10 +9,14 @@ LABEL maintainer="CodeLibs" \
       org.opencontainers.image.vendor="CodeLibs" \
       org.opencontainers.image.licenses="Apache-2.0"
 
-ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:3.8.0
-ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:3.8.0
-ARG MINHASH_PLUGIN=org.codelibs.opensearch:opensearch-minhash:3.8.0
-ARG CONFIGSYNC_PLUGIN=org.codelibs.opensearch:opensearch-configsync:3.8.0
+# Fess plugins are distributed through the CodeLibs repository, so they are
+# installed from an explicit URL rather than Maven Central coordinates.
+ARG PLUGIN_VERSION=3.8.0
+ARG PLUGIN_REPO_URL=https://maven.codelibs.org/release/org/codelibs/opensearch
+ARG ANALYSIS_EXTENSION_PLUGIN=${PLUGIN_REPO_URL}/opensearch-analysis-extension/${PLUGIN_VERSION}/opensearch-analysis-extension-${PLUGIN_VERSION}.zip
+ARG ANALYSIS_FESS_PLUGIN=${PLUGIN_REPO_URL}/opensearch-analysis-fess/${PLUGIN_VERSION}/opensearch-analysis-fess-${PLUGIN_VERSION}.zip
+ARG MINHASH_PLUGIN=${PLUGIN_REPO_URL}/opensearch-minhash/${PLUGIN_VERSION}/opensearch-minhash-${PLUGIN_VERSION}.zip
+ARG CONFIGSYNC_PLUGIN=${PLUGIN_REPO_URL}/opensearch-configsync/${PLUGIN_VERSION}/opensearch-configsync-${PLUGIN_VERSION}.zip
 
 # Remove unnecessary plugins and install Fess-specific plugins
 RUN /usr/share/opensearch/bin/opensearch-plugin remove opensearch-security-analytics && \

--- a/opensearch/3.8/Dockerfile
+++ b/opensearch/3.8/Dockerfile
@@ -1,0 +1,31 @@
+FROM public.ecr.aws/opensearchproject/opensearch:3.8.0
+
+# Metadata labels for better container management
+LABEL maintainer="CodeLibs" \
+      org.opencontainers.image.title="Fess OpenSearch" \
+      org.opencontainers.image.description="OpenSearch customized for Fess with required plugins" \
+      org.opencontainers.image.url="https://fess.codelibs.org/" \
+      org.opencontainers.image.source="https://github.com/codelibs/docker-fess" \
+      org.opencontainers.image.vendor="CodeLibs" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:3.8.0
+ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:3.8.0
+ARG MINHASH_PLUGIN=org.codelibs.opensearch:opensearch-minhash:3.8.0
+ARG CONFIGSYNC_PLUGIN=org.codelibs.opensearch:opensearch-configsync:3.8.0
+
+# Remove unnecessary plugins and install Fess-specific plugins
+RUN /usr/share/opensearch/bin/opensearch-plugin remove opensearch-security-analytics && \
+    /usr/share/opensearch/bin/opensearch-plugin remove opensearch-performance-analyzer && \
+    /usr/share/opensearch/bin/opensearch-plugin install $ANALYSIS_FESS_PLUGIN -b  && \
+    /usr/share/opensearch/bin/opensearch-plugin install $ANALYSIS_EXTENSION_PLUGIN -b && \
+    /usr/share/opensearch/bin/opensearch-plugin install $MINHASH_PLUGIN -b && \
+    /usr/share/opensearch/bin/opensearch-plugin install $CONFIGSYNC_PLUGIN -b && \
+    echo 'configsync.config_path: ${FESS_DICTIONARY_PATH}' >> /usr/share/opensearch/config/opensearch.yml && \
+    mkdir /usr/share/opensearch/config/dictionary && \
+    chown opensearch /usr/share/opensearch/config/dictionary
+
+# Add health check to monitor OpenSearch health
+HEALTHCHECK --interval=30s --timeout=10s --start-period=90s --retries=3 \
+    CMD curl -f http://localhost:9200/_cluster/health || exit 1
+


### PR DESCRIPTION
## Summary

Add `opensearch/3.8/Dockerfile`, following the existing `opensearch/3.7` layout:
the OpenSearch 3.8.0 base image plus the four Fess plugins
(`analysis-extension`, `analysis-fess`, `minhash`, `configsync`).

The plugins are installed from the CodeLibs repository rather than Maven
Central. `opensearch-plugin install` resolves Maven coordinates against Maven
Central only, so the coordinate form cannot express another repository — the
plugins are installed from an explicit release URL instead. The repository base
and the plugin version are separate build arguments, so a build can be pointed
at another mirror without editing the Dockerfile.

## Blocked on plugin publication

The four plugins are **not published to the CodeLibs repository yet**. Only
`module` and `opensearch-ml*` currently exist under
`org/codelibs/opensearch/` there, so a default build fails:

```
Downloading .../opensearch-analysis-fess/3.8.0/opensearch-analysis-fess-3.8.0.zip
Failed installing .../opensearch-analysis-fess-3.8.0.zip
```

This PR should merge once the 3.8.0 plugins are published.

## Verification

The URL layout and the install mechanism are verified independently of
publication, by pointing the same build argument at a reachable mirror of the
identical path structure:

```
docker build --build-arg PLUGIN_REPO_URL=<mirror>/org/codelibs/opensearch ./opensearch/3.8/
```

All four plugins download and install, confirming the build-argument expansion
and the URL form are correct. The resulting image reaches a green cluster with
all four plugins present at 3.8.0, on OpenSearch 3.8.0 / Lucene 10.5.0.

## Scope

Dockerfile only, matching how 3.7.0 was added in #59. The compose files and the
README compatibility table track the released Fess version and the published
`fess-opensearch` tags, so they are bumped separately once the 3.8.0 image is
published — the same split already used for 3.5.0 (#50), 3.6.0 (#52) and
3.7.0 (#59, #60). Older `opensearch/*` directories are left on their existing
coordinate form, since they describe already-published images.
