### PR TITLE
fix(opensearch): install 3.8 plugins from Maven Central

### DIFF
--- a/opensearch/3.8/Dockerfile
+++ b/opensearch/3.8/Dockerfile
@@ -9,14 +9,10 @@ LABEL maintainer="CodeLibs" \
       org.opencontainers.image.vendor="CodeLibs" \
       org.opencontainers.image.licenses="Apache-2.0"
 
-# Fess plugins are distributed through the CodeLibs repository, so they are
-# installed from an explicit URL rather than Maven Central coordinates.
-ARG PLUGIN_VERSION=3.8.0
-ARG PLUGIN_REPO_URL=https://maven.codelibs.org/release/org/codelibs/opensearch
-ARG ANALYSIS_EXTENSION_PLUGIN=${PLUGIN_REPO_URL}/opensearch-analysis-extension/${PLUGIN_VERSION}/opensearch-analysis-extension-${PLUGIN_VERSION}.zip
-ARG ANALYSIS_FESS_PLUGIN=${PLUGIN_REPO_URL}/opensearch-analysis-fess/${PLUGIN_VERSION}/opensearch-analysis-fess-${PLUGIN_VERSION}.zip
-ARG MINHASH_PLUGIN=${PLUGIN_REPO_URL}/opensearch-minhash/${PLUGIN_VERSION}/opensearch-minhash-${PLUGIN_VERSION}.zip
-ARG CONFIGSYNC_PLUGIN=${PLUGIN_REPO_URL}/opensearch-configsync/${PLUGIN_VERSION}/opensearch-configsync-${PLUGIN_VERSION}.zip
+ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:3.8.0
+ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:3.8.0
+ARG MINHASH_PLUGIN=org.codelibs.opensearch:opensearch-minhash:3.8.0
+ARG CONFIGSYNC_PLUGIN=org.codelibs.opensearch:opensearch-configsync:3.8.0
 
 # Remove unnecessary plugins and install Fess-specific plugins
 RUN /usr/share/opensearch/bin/opensearch-plugin remove opensearch-security-analytics && \


### PR DESCRIPTION
## Problem

Building the `opensearch/3.8` image fails on the plugin install step:

```
-> Installing https://maven.codelibs.org/release/org/codelibs/opensearch/opensearch-analysis-fess/3.8.0/opensearch-analysis-fess-3.8.0.zip
-> Failed installing ...
Exception in thread "main" java.io.FileNotFoundException: ...
```

## Cause

#62 switched this image from Maven coordinates to explicit
`maven.codelibs.org` URLs. The four Fess OpenSearch plugins
(`opensearch-analysis-fess`, `opensearch-analysis-extension`,
`opensearch-minhash`, `opensearch-configsync`) are not distributed there —
they are published to Maven Central. Only the repackaged OpenSearch module
jars and the Fess webapp plugins moved to the CodeLibs repository.

All four artifacts return 404 on `maven.codelibs.org` and 200 on Maven
Central, for 3.5.0 through 3.8.0.

## Fix

Restore the Maven coordinate form used by 3.7 and every earlier image.
`opensearch-plugin install` resolves coordinates against Maven Central.
`opensearch/3.8/Dockerfile` is now identical to `opensearch/3.7/Dockerfile`
apart from the version literals.

## Verification

`docker build` on the fixed Dockerfile succeeds. The four plugins are
reported as downloaded "from maven central" and are present in the image:

```
$ docker run --rm --entrypoint ls <image> /usr/share/opensearch/plugins
analysis-extension  analysis-fess  configsync  minhash  ...
```

`opensearch-security-analytics` and `opensearch-performance-analyzer` are
absent, so the `remove` steps still work as intended.
