### PR TITLE
feat(opensearch): install snapshot plugins from maven.codelibs.org

### DIFF
--- a/opensearch/snapshot/Dockerfile
+++ b/opensearch/snapshot/Dockerfile
@@ -1,9 +1,15 @@
-FROM public.ecr.aws/opensearchproject/opensearch:3.3.2
+FROM public.ecr.aws/opensearchproject/opensearch:3.8.0
 
-ARG ANALYSIS_EXTENSION_PLUGIN=org.codelibs.opensearch:opensearch-analysis-extension:3.3.1
-ARG ANALYSIS_FESS_PLUGIN=org.codelibs.opensearch:opensearch-analysis-fess:3.3.1
-ARG MINHASH_PLUGIN=org.codelibs.opensearch:opensearch-minhash:3.3.1
-ARG CONFIGSYNC_PLUGIN=org.codelibs.opensearch:opensearch-configsync:3.3.1
+# The Fess plugins are published to maven.codelibs.org instead of Maven Central, so
+# they are installed by URL: the opensearch-plugin installer resolves the
+# group:artifact:version form against repo1.maven.org only. build_os.sh overrides
+# these arguments with timestamped snapshot URLs from the snapshot repository.
+ARG PLUGIN_REPO=https://maven.codelibs.org/release/org/codelibs/opensearch
+ARG PLUGIN_VERSION=3.8.1
+ARG ANALYSIS_EXTENSION_PLUGIN=${PLUGIN_REPO}/opensearch-analysis-extension/${PLUGIN_VERSION}/opensearch-analysis-extension-${PLUGIN_VERSION}.zip
+ARG ANALYSIS_FESS_PLUGIN=${PLUGIN_REPO}/opensearch-analysis-fess/${PLUGIN_VERSION}/opensearch-analysis-fess-${PLUGIN_VERSION}.zip
+ARG MINHASH_PLUGIN=${PLUGIN_REPO}/opensearch-minhash/${PLUGIN_VERSION}/opensearch-minhash-${PLUGIN_VERSION}.zip
+ARG CONFIGSYNC_PLUGIN=${PLUGIN_REPO}/opensearch-configsync/${PLUGIN_VERSION}/opensearch-configsync-${PLUGIN_VERSION}.zip
 
 RUN /usr/share/opensearch/bin/opensearch-plugin remove opensearch-security-analytics && \
     /usr/share/opensearch/bin/opensearch-plugin remove opensearch-performance-analyzer && \


### PR DESCRIPTION
## Summary

The Fess plugins for OpenSearch are published to maven.codelibs.org from 3.8.1 onwards. The `opensearch-plugin` installer resolves the `group:artifact:version` form against `repo1.maven.org` only, so the snapshot image installs them by URL instead.

## Changes

- `opensearch/snapshot/Dockerfile`: replace the Maven coordinate build arguments with URLs built from `PLUGIN_REPO` and `PLUGIN_VERSION`.
- Update the base image from 3.3.2 to 3.8.0 so it matches the OpenSearch version the plugin descriptors require.

The images for released versions up to 3.8.0 are unchanged. Those artifacts stay on Maven Central and are not mirrored to maven.codelibs.org, so rewriting them would break those builds.

## Verification

- `docker buildx build --check ./opensearch/snapshot/` reports no warnings.
- `docker buildx build --call=outline ./opensearch/snapshot/` resolves the build arguments to the expected maven.codelibs.org URLs.
