### PR TITLE
fix(compose): install the pango library the Playwright image is missing

### DIFF
--- a/compose/playwright/Dockerfile
+++ b/compose/playwright/Dockerfile
@@ -2,6 +2,7 @@ FROM ghcr.io/codelibs/fess:15.7.0-noble
 
 RUN apt-get update && \
     apt-get install -y \
-    libxcomposite1 libxfixes3 libatk1.0-0 libatk-bridge2.0-0 libxkbcommon0 libxdamage1 libgbm1 libasound2t64 libatspi2.0-0 && \
+    libxcomposite1 libxfixes3 libatk1.0-0 libatk-bridge2.0-0 libxkbcommon0 libxdamage1 libgbm1 libasound2t64 libatspi2.0-0 \
+    libpango-1.0-0 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Problem

The Playwright compose image is missing one of the shared libraries the browser needs. Running Playwright's own dependency check inside the built image reports it:

```
Playwright Host validation warning:
  Host system is missing dependencies to run browsers.
  Alternatively, use apt:
      apt-get install libpango-1.0-0
```

The other libraries in the `apt-get install` line cover the rest of the list, so this is the only gap.

## Change

Add `libpango-1.0-0` to `compose/playwright/Dockerfile`.

## Verification

Built the image from this branch and confirmed the package is installed:

```
libpango-1.0-0:arm64 1.52.1+ds-1build1
```

Re-ran Playwright's dependency check on a noble-based Fess image with the package present: it now completes with no warning at all, so nothing else is missing behind it.
