### PR TITLE
feat(fess): add Fess 15.8.0 images and bump references

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ environment:
   - FESS_JAVA_OPTS=-server -Xms1g -Xmx1g
   
   # Plugin installation
-  - FESS_PLUGINS=fess-webapp-semantic-search:15.7.0 fess-ds-wikipedia:15.7.0
+  - FESS_PLUGINS=fess-webapp-semantic-search:15.8.0 fess-ds-wikipedia:15.8.0
 ```
 
 ### Multi-Instance Deployment
@@ -150,10 +150,10 @@ Each instance uses separate indices for data isolation.
 **Fess Application:**
 ```bash
 # Build specific version
-docker build --rm -t ghcr.io/codelibs/fess:15.7.0 ./fess/15.7/
+docker build --rm -t ghcr.io/codelibs/fess:15.8.0 ./fess/15.8/
 
 # Build with custom args
-docker build --build-arg FESS_VERSION=15.7.0 -t my-fess ./fess/15.7/
+docker build --build-arg FESS_VERSION=15.8.0 -t my-fess ./fess/15.8/
 ```
 
 **OpenSearch with Fess Plugins:**
@@ -167,8 +167,8 @@ docker build --rm -t ghcr.io/codelibs/fess-opensearch:3.7.0 ./opensearch/3.7/
 ```
 docker-fess/
 ├── fess/                    # Fess Docker images
-│   ├── 15.7/               # Latest stable version
-│   ├── 15.6/               # Previous versions
+│   ├── 15.8/               # Latest stable version
+│   ├── 15.7/               # Previous versions
 │   └── snapshot/           # Development builds
 ├── opensearch/             # OpenSearch images with Fess plugins
 │   ├── 3.7/               # Latest OpenSearch
@@ -203,6 +203,7 @@ FESS_JAVA_OPTS="-Dfess.config.index.document.search.index=myapp.search \
 
 | Fess Version | OpenSearch | Elasticsearch | Java | Base Image |
 |--------------|------------|---------------|------|------------|
+| 15.8.0 | 3.8.0 | - | 21 | Alpine/Ubuntu Noble/Amazon Linux 2023 |
 | 15.7.0 | 3.7.0 | - | 21 | Alpine/Ubuntu Noble/Amazon Linux 2023 |
 | 15.6.0 | 3.6.0 | - | 21 | Alpine/Ubuntu Noble/Amazon Linux 2023 |
 | 15.5.1 | 3.5.0 | - | 21 | Alpine/Ubuntu Noble/Amazon Linux 2023 |
@@ -276,7 +277,7 @@ Install additional Fess plugins:
 
 ```yaml
 environment:
-  - FESS_PLUGINS=fess-webapp-semantic-search:15.7.0 fess-ds-wikipedia:15.7.0
+  - FESS_PLUGINS=fess-webapp-semantic-search:15.8.0 fess-ds-wikipedia:15.8.0
 ```
 
 ### SSL/TLS Configuration

--- a/compose/compose-gemini.yaml
+++ b/compose/compose-gemini.yaml
@@ -7,5 +7,5 @@
 services:
   fess01:
     environment:
-      - "FESS_PLUGINS=fess-llm-gemini:15.7.0"
+      - "FESS_PLUGINS=fess-llm-gemini:15.8.0"
       - "FESS_JAVA_OPTS=-Dfess.config.rag.chat.enabled=true -Dfess.config.rag.llm.gemini.api.key=${GEMINI_API_KEY:-} -Dfess.config.rag.llm.gemini.model=${GEMINI_MODEL:-gemini-2.5-flash} -Dfess.system.rag.llm.name=gemini"

--- a/compose/compose-ollama.yaml
+++ b/compose/compose-ollama.yaml
@@ -6,7 +6,7 @@
 services:
   fess01:
     environment:
-      - "FESS_PLUGINS=fess-llm-ollama:15.7.0"
+      - "FESS_PLUGINS=fess-llm-ollama:15.8.0"
       - "FESS_JAVA_OPTS=-Dfess.config.rag.chat.enabled=true -Dfess.config.rag.llm.ollama.api.url=http://ollama01:11434"
     depends_on:
       - ollama01

--- a/compose/compose-openai.yaml
+++ b/compose/compose-openai.yaml
@@ -7,5 +7,5 @@
 services:
   fess01:
     environment:
-      - "FESS_PLUGINS=fess-llm-openai:15.7.0"
+      - "FESS_PLUGINS=fess-llm-openai:15.8.0"
       - "FESS_JAVA_OPTS=-Dfess.config.rag.chat.enabled=true -Dfess.config.rag.llm.openai.api.key=${OPENAI_API_KEY:-} -Dfess.config.rag.llm.openai.model=${OPENAI_MODEL:-gpt-5-mini} -Dfess.system.rag.llm.name=openai"

--- a/compose/compose.yaml
+++ b/compose/compose.yaml
@@ -1,12 +1,12 @@
 services:
   fess01:
-    image: ghcr.io/codelibs/fess:15.7.0
+    image: ghcr.io/codelibs/fess:15.8.0
     # build: ./playwright # use Playwright
     container_name: fess01
     environment:
       - "SEARCH_ENGINE_HTTP_URL=http://search01:9200"
       - "FESS_DICTIONARY_PATH=${FESS_DICTIONARY_PATH:-/usr/share/opensearch/config/dictionary/}"
-      # - "FESS_PLUGINS=fess-webapp-semantic-search:15.7.0 fess-ds-wikipedia:15.7.0"
+      # - "FESS_PLUGINS=fess-webapp-semantic-search:15.8.0 fess-ds-wikipedia:15.8.0"
     ports:
       - "8080:8080"
     networks:

--- a/compose/multi-instance/compose-fess01.yaml
+++ b/compose/multi-instance/compose-fess01.yaml
@@ -1,6 +1,6 @@
 services:
   fess01:
-    image: ghcr.io/codelibs/fess:15.7.0
+    image: ghcr.io/codelibs/fess:15.8.0
     container_name: fess01
     environment:
       - "SEARCH_ENGINE_HTTP_URL=http://search01:9200"

--- a/compose/multi-instance/compose-fess02.yaml
+++ b/compose/multi-instance/compose-fess02.yaml
@@ -1,6 +1,6 @@
 services:
   fess02:
-    image: ghcr.io/codelibs/fess:15.7.0
+    image: ghcr.io/codelibs/fess:15.8.0
     container_name: fess02
     environment:
       - "SEARCH_ENGINE_HTTP_URL=http://search01:9200"

--- a/compose/playwright/Dockerfile
+++ b/compose/playwright/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/codelibs/fess:15.7.0-noble
+FROM ghcr.io/codelibs/fess:15.8.0-noble
 
 RUN apt-get update && \
     apt-get install -y \

--- a/compose/vanilla/compose.yaml
+++ b/compose/vanilla/compose.yaml
@@ -1,12 +1,12 @@
 services:
   fess01:
-    image: ghcr.io/codelibs/fess:15.7.0
+    image: ghcr.io/codelibs/fess:15.8.0
     container_name: fess01
     environment:
       - "SEARCH_ENGINE_HTTP_URL=http://search01:9200"
       - "SEARCH_ENGINE_TYPE=cloud"
       - "FESS_DICTIONARY_PATH=${FESS_DICTIONARY_PATH:-/usr/share/opensearch/config/dictionary/}"
-      # - "FESS_PLUGINS=fess-webapp-semantic-search:15.7.0 fess-ds-wikipedia:15.7.0"
+      # - "FESS_PLUGINS=fess-webapp-semantic-search:15.8.0 fess-ds-wikipedia:15.8.0"
     ports:
       - "8080:8080"
     networks:

--- a/fess/15.8-al2023/Dockerfile
+++ b/fess/15.8-al2023/Dockerfile
@@ -1,0 +1,73 @@
+# Base image with Java 21 on Amazon Linux 2023
+FROM amazoncorretto:21-al2023
+
+# Metadata labels for better container management
+LABEL maintainer="CodeLibs" \
+      org.opencontainers.image.title="Fess" \
+      org.opencontainers.image.description="Enterprise search server powered by OpenSearch" \
+      org.opencontainers.image.url="https://fess.codelibs.org/" \
+      org.opencontainers.image.source="https://github.com/codelibs/docker-fess" \
+      org.opencontainers.image.vendor="CodeLibs" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+# Set environment variables for Fess application
+ENV FESS_APP_TYPE=docker
+
+# Set Fess version as a build argument
+ARG FESS_VERSION=15.8.0
+
+# This ARG is used to bust the cache when needed
+ARG CACHEBUST=1
+
+# Combine RUN instructions to reduce image layers and size
+RUN set -x && \
+    # 1. Install dependencies without weak dependencies
+    dnf install -y --setopt=install_weak_deps=false \
+        ImageMagick \
+        poppler-utils \
+        initscripts \
+        glibc-langpack-en && \
+    # 2. Create a dedicated user and group for Fess
+    groupadd -g 1001 fess && \
+    useradd -u 1001 -g fess --system --no-create-home --home /var/lib/fess fess && \
+    # 3. Download and verify Fess package
+    curl -LfsSo /tmp/fess-${FESS_VERSION}.rpm \
+      https://github.com/codelibs/fess/releases/download/fess-${FESS_VERSION}/fess-${FESS_VERSION}.rpm && \
+    # Verify download by checking file size is reasonable (>5MB for a valid Fess rpm package)
+    [ $(stat -c%s /tmp/fess-${FESS_VERSION}.rpm) -gt 5242880 ] || (echo "Downloaded file too small, likely corrupted" && exit 1) && \
+    # 4. Install Fess from the rpm package
+    rpm -i --nodeps /tmp/fess-${FESS_VERSION}.rpm && \
+    rm -f /tmp/fess-${FESS_VERSION}.rpm && \
+    # 5. Uncomment logging configurations in log4j2.xml files for console output
+    for f in $(find /usr/share/fess/app/WEB-INF/ -type f | grep log4j2.xml) ; do \
+      sed -i 's/[^\t]*<!-- //' $f; sed -i 's/\/> -->/\/>/' $f; done  && \
+    # 6. Create directory for custom configurations
+    mkdir /opt/fess && \
+    chown -R fess:fess /opt/fess && \
+    # 7. Configure Fess to load custom configurations from /opt/fess
+    sed -i -e 's#FESS_CLASSPATH="$FESS_CONF_PATH:$FESS_CLASSPATH"#FESS_CLASSPATH="$FESS_OVERRIDE_CONF_PATH:$FESS_CONF_PATH:$FESS_CLASSPATH"#g' /usr/share/fess/bin/fess && \
+    # 8. Set Fess environment variables
+    echo "export FESS_APP_TYPE=$FESS_APP_TYPE" >> /usr/share/fess/bin/fess.in.sh && \
+    echo "export FESS_OVERRIDE_CONF_PATH=/opt/fess" >> /usr/share/fess/bin/fess.in.sh && \
+    # 9. Clean up dnf cache to reduce image size
+    dnf clean all
+
+# Set working directory
+WORKDIR /usr/share/fess
+
+# Expose Fess port
+EXPOSE 8080
+
+# Copy the startup script into the container and set permissions
+COPY run.sh /usr/share/fess/run.sh
+RUN chmod +x /usr/share/fess/run.sh
+
+# Add health check to monitor container health
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+    CMD curl -f http://localhost:8080/api/v2/health || exit 1
+
+# The entrypoint script `run.sh` performs setup tasks that require root.
+# Therefore, the container must be started as root.
+# The script itself is responsible for starting the Fess process.
+USER root
+ENTRYPOINT ["/usr/share/fess/run.sh"]

--- a/fess/15.8-al2023/run.sh
+++ b/fess/15.8-al2023/run.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+temp_dir=/tmp
+plugin_dir=/usr/share/fess/app/WEB-INF/plugin
+
+print_log() {
+  log_level=$1
+  message=$2
+  echo '{"@timestamp":"'$(date -u "+%Y-%m-%dT%H:%M:%S.%3NZ")'","log.level": "'${log_level}'","message":"'"${message}"'", "ecs.version": "1.2.0","service.name":"fess","event.dataset":"app","process.thread.name":"bootstrap","log.logger":"run.sh"}'
+}
+
+if [[ "x${FESS_DICTIONARY_PATH}" != "x" ]] ; then
+  sed -i -e "s|^FESS_DICTIONARY_PATH=.*|FESS_DICTIONARY_PATH=${FESS_DICTIONARY_PATH}|" /etc/sysconfig/fess
+fi
+
+if [[ "x${FESS_PORT}" != "x" ]] ; then
+  sed -i -e "s|^FESS_PORT=.*|FESS_PORT=${FESS_PORT}|" /etc/sysconfig/fess
+fi
+
+if [[ "x${FESS_HEAP_SIZE}" != "x" ]] ; then
+  sed -i -e "s|^FESS_HEAP_SIZE=.*|FESS_HEAP_SIZE=${FESS_HEAP_SIZE}|" /etc/sysconfig/fess
+fi
+
+if [[ "x${SEARCH_ENGINE_HTTP_URL}" != "x" ]] ; then
+  sed -i -e "s|^SEARCH_ENGINE_HTTP_URL=.*|SEARCH_ENGINE_HTTP_URL=${SEARCH_ENGINE_HTTP_URL}|" /etc/sysconfig/fess
+elif [[ "x${ES_HTTP_URL}" != "x" ]] ; then
+  print_log WARN "ES_HTTP_URL is deprecated."
+  sed -i -e "s|^SEARCH_ENGINE_HTTP_URL=.*|SEARCH_ENGINE_HTTP_URL=${ES_HTTP_URL}|" /etc/sysconfig/fess
+else
+  SEARCH_ENGINE_HTTP_URL=http://localhost:9200
+fi
+
+if [[ "x${SEARCH_ENGINE_TYPE}" != "x" ]] ; then
+  FESS_JAVA_OPTS="${FESS_JAVA_OPTS} -Dfess.config.search_engine.type=${SEARCH_ENGINE_TYPE}"
+elif [[ "x${ES_TYPE}" != "x" ]] ; then
+  print_log WARN "ES_TYPE is deprecated."
+  FESS_JAVA_OPTS="${FESS_JAVA_OPTS} -Dfess.config.search_engine.type=${ES_TYPE}"
+fi
+
+if [[ "x${SEARCH_ENGINE_USERNAME}" != "x" ]] ; then
+  FESS_JAVA_OPTS="${FESS_JAVA_OPTS} -Dfess.config.search_engine.username=${SEARCH_ENGINE_USERNAME}"
+elif [[ "x${ES_USERNAME}" != "x" ]] ; then
+  print_log WARN "ES_USERNAME is deprecated."
+  FESS_JAVA_OPTS="${FESS_JAVA_OPTS} -Dfess.config.search_engine.username=${ES_USERNAME}"
+fi
+
+if [[ "x${SEARCH_ENGINE_PASSWORD}" != "x" ]] ; then
+  FESS_JAVA_OPTS="${FESS_JAVA_OPTS} -Dfess.config.search_engine.password=${SEARCH_ENGINE_PASSWORD}"
+elif [[ "x${ES_PASSWORD}" != "x" ]] ; then
+  print_log WARN "ES_PASSWORD is deprecated."
+  FESS_JAVA_OPTS="${FESS_JAVA_OPTS} -Dfess.config.search_engine.password=${ES_PASSWORD}"
+fi
+
+if [[ "x${FESS_JAVA_OPTS}" != "x" ]] ; then
+  echo "FESS_JAVA_OPTS=\"${FESS_JAVA_OPTS}\"" >> /etc/sysconfig/fess
+fi
+
+if [[ "x${PING_RETRIES}" = "x" ]] ; then
+  PING_RETRIES=3
+fi
+
+if [[ "x${PING_INTERVAL}" = "x" ]] ; then
+  PING_INTERVAL=60
+fi
+
+download_plugin() {
+  plugin_id=$1
+  plugin_name=$(echo ${plugin_id} | sed -e "s/:.*//")
+  plugin_version=$(echo ${plugin_id} | sed -e "s/.*://")
+  if [[ ${plugin_name} == fess-ds-* ]] \
+    || [[ ${plugin_name} == fess-ingest-* ]] \
+    || [[ ${plugin_name} == fess-script-* ]] \
+    || [[ ${plugin_name} == fess-llm-* ]] \
+    || [[ ${plugin_name} == fess-theme-* ]] \
+    || [[ ${plugin_name} == fess-webapp-* ]] \
+    ; then
+    plugin_file="${plugin_name}-${plugin_version}.jar"
+    if [[ ${plugin_version} == *-SNAPSHOT ]] ; then
+      metadata_file="${temp_dir}/maven-metadata.$$"
+      metadata_url="https://oss.sonatype.org/content/repositories/snapshots/org/codelibs/fess/${plugin_name}/${plugin_version}/maven-metadata.xml"
+      if ! curl -fs -o "${metadata_file}" "${metadata_url}" ; then
+        print_log ERROR "Failed to download from ${metadata_url}."
+        return
+      fi
+      version_timestamp=$(cat ${metadata_file} | grep "<timestamp>" | head -n1 | sed -e "s,.*timestamp>\(.*\)</timestamp.*,\1,")
+      version_buildnum=$(cat ${metadata_file} | grep "<buildNumber>" | head -n1 | sed -e "s,.*buildNumber>\(.*\)</buildNumber.*,\1,")
+      rm -f ${metadata_file}
+      plugin_file=$(echo ${plugin_file} | sed -e "s/SNAPSHOT/${version_timestamp}-${version_buildnum}/")
+      plugin_url="https://oss.sonatype.org/content/repositories/snapshots/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
+    else
+      plugin_url="https://repo.maven.apache.org/maven2/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
+    fi
+    print_log INFO "Downloading from ${plugin_url}"
+    if ! curl -fs -o "${temp_dir}/${plugin_file}" "${plugin_url}" > /dev/null; then
+      print_log ERROR "Failed to download ${plugin_file}."
+      return
+    fi
+    if ! curl -fs -o "${temp_dir}/${plugin_file}.sha1" "${plugin_url}.sha1" > /dev/null; then
+      print_log ERROR "Failed to download ${plugin_file}.sha1."
+      return
+    fi
+    if ! echo "$(cat "${temp_dir}/${plugin_file}.sha1") ${temp_dir}/${plugin_file}" | sha1sum -c > /dev/null ; then
+      print_log ERROR "Invalid checksum for ${plugin_file}."
+      return
+    fi
+    print_log INFO "Installing ${plugin_file}"
+    rm -f "${temp_dir}/${plugin_file}.sha1"
+    mv "${temp_dir}/${plugin_file}" "${plugin_dir}"
+    chown fess:fess "${plugin_dir}/${plugin_file}"
+  fi
+}
+
+start_fess() {
+  . /etc/init.d/functions
+  rm -f /usr/bin/java
+  ln -s /usr/lib/jvm/java/bin/java /usr/bin/java
+  touch /var/log/fess/fess-crawler.log \
+        /var/log/fess/fess-llm.log \
+        /var/log/fess/fess-suggest.log \
+        /var/log/fess/fess-thumbnail.log \
+        /var/log/fess/fess-urls.log \
+        /var/log/fess/audit.log \
+        /var/log/fess/fess.log
+  chown fess:fess /var/log/fess/fess-crawler.log \
+                  /var/log/fess/fess-llm.log \
+                  /var/log/fess/fess-suggest.log \
+                  /var/log/fess/fess-thumbnail.log \
+                  /var/log/fess/fess-urls.log \
+                  /var/log/fess/audit.log \
+                  /var/log/fess/fess.log
+  tail -qF /var/log/fess/fess-crawler.log /var/log/fess/fess-llm.log /var/log/fess/fess-suggest.log /var/log/fess/fess-thumbnail.log /var/log/fess/fess.log /var/log/fess/audit.log 2>/dev/null &
+  print_log INFO "Starting Fess service."
+  /etc/init.d/fess start > /dev/null 2>&1
+}
+
+wait_app() {
+  if [[ "x${FESS_CONTEXT_PATH}" = "x" ]] ; then
+    ping_path=/api/v2/health
+  else
+    ping_path=${FESS_CONTEXT_PATH}/api/v2/health
+  fi
+  while true ; do
+    status=$(curl -w '%{http_code}\n' -s -o /dev/null "http://localhost:8080${ping_path}")
+    if [[ x"${status}" = x200 ]] ; then
+      error_count=0
+    else
+      error_count=$((error_count + 1))
+    fi
+    if [[ ${error_count} -ge ${PING_RETRIES} ]] ; then
+      print_log ERROR "Fess is not available."
+      exit 1
+    fi
+    sleep ${PING_INTERVAL}
+  done
+}
+
+for plugin_id in $FESS_PLUGINS ; do
+  download_plugin $(echo ${plugin_id} | sed -e "s,/,,g")
+done
+
+start_fess
+
+if [[ "x${RUN_SHELL}" = "xtrue" ]] ; then
+  /bin/bash
+else
+  wait_app
+fi

--- a/fess/15.8-noble/Dockerfile
+++ b/fess/15.8-noble/Dockerfile
@@ -1,0 +1,77 @@
+# Base image with Java 21 JRE on Ubuntu Noble
+FROM eclipse-temurin:21-jre-noble
+
+# Metadata labels for better container management
+LABEL maintainer="CodeLibs" \
+      org.opencontainers.image.title="Fess" \
+      org.opencontainers.image.description="Enterprise search server powered by OpenSearch" \
+      org.opencontainers.image.url="https://fess.codelibs.org/" \
+      org.opencontainers.image.source="https://github.com/codelibs/docker-fess" \
+      org.opencontainers.image.vendor="CodeLibs" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+# Set environment variables for Fess application
+ENV FESS_APP_TYPE=docker
+
+# Set Fess version as a build argument
+ARG FESS_VERSION=15.8.0
+
+# This ARG is used to bust the cache when needed
+ARG CACHEBUST=1
+
+# Combine RUN instructions to reduce image layers and size
+RUN set -x && \
+    # 1. Update package list and install dependencies without recommended packages
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        imagemagick \
+        unoconv \
+        python3-setuptools \
+        poppler-utils && \
+    # 2. Create a dedicated user and group for Fess
+    groupadd -g 1001 fess && \
+    useradd -u 1001 -g fess --system --no-create-home --home /var/lib/fess fess && \
+    # 3. Download and verify Fess package
+    curl -LfsSo /tmp/fess-${FESS_VERSION}.deb \
+      https://github.com/codelibs/fess/releases/download/fess-${FESS_VERSION}/fess-${FESS_VERSION}.deb && \
+    # Note: Checksum verification would be ideal but snapshot builds may not have published checksums
+    # Verify download by checking file size is reasonable (>5MB for a valid Fess deb package)
+    [ $(stat -c%s /tmp/fess-${FESS_VERSION}.deb) -gt 5242880 ] || (echo "Downloaded file too small, likely corrupted" && exit 1) && \
+    # 4. Install Fess from the deb package
+    dpkg -i /tmp/fess-${FESS_VERSION}.deb && \
+    rm -f /tmp/fess-${FESS_VERSION}.deb && \
+    # 5. Uncomment logging configurations in log4j2.xml files for console output
+    for f in $(find /usr/share/fess/app/WEB-INF/ -type f | grep log4j2.xml) ; do \
+      sed -i 's/[^\t]*<!-- //' $f; sed -i 's/\/> -->/\/>/' $f; done  && \
+    # 6. Create directory for custom configurations
+    mkdir /opt/fess && \
+    chown -R fess:fess /opt/fess && \
+    # 7. Configure Fess to load custom configurations from /opt/fess
+    sed -i -e 's#FESS_CLASSPATH="$FESS_CONF_PATH:$FESS_CLASSPATH"#FESS_CLASSPATH="$FESS_OVERRIDE_CONF_PATH:$FESS_CONF_PATH:$FESS_CLASSPATH"#g' /usr/share/fess/bin/fess && \
+    # 8. Set Fess environment variables
+    echo "export FESS_APP_TYPE=$FESS_APP_TYPE" >> /usr/share/fess/bin/fess.in.sh && \
+    echo "export FESS_OVERRIDE_CONF_PATH=/opt/fess" >> /usr/share/fess/bin/fess.in.sh && \
+    # 9. Clean up apt cache to reduce image size
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /usr/share/fess
+
+# Expose Fess port
+EXPOSE 8080
+
+# Copy the startup script into the container and set permissions
+COPY run.sh /usr/share/fess/run.sh
+RUN chmod +x /usr/share/fess/run.sh
+
+# Add health check to monitor container health
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+    CMD curl -f http://localhost:8080/api/v2/health || exit 1
+
+# The entrypoint script `run.sh` performs setup tasks that require root.
+# Therefore, the container must be started as root.
+# The script itself is responsible for starting the Fess process.
+USER root
+ENTRYPOINT ["/usr/share/fess/run.sh"]

--- a/fess/15.8-noble/run.sh
+++ b/fess/15.8-noble/run.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+
+temp_dir=/tmp
+plugin_dir=/usr/share/fess/app/WEB-INF/plugin
+
+print_log() {
+  log_level=$1
+  message=$2
+  echo '{"@timestamp":"'$(date -u "+%Y-%m-%dT%H:%M:%S.%3NZ")'","log.level": "'${log_level}'","message":"'"${message}"'", "ecs.version": "1.2.0","service.name":"fess","event.dataset":"app","process.thread.name":"bootstrap","log.logger":"run.sh"}'
+}
+
+if [[ "x${FESS_DICTIONARY_PATH}" != "x" ]] ; then
+  sed -i -e "s|^FESS_DICTIONARY_PATH=.*|FESS_DICTIONARY_PATH=${FESS_DICTIONARY_PATH}|" /etc/default/fess
+fi
+
+if [[ "x${FESS_PORT}" != "x" ]] ; then
+  sed -i -e "s|^FESS_PORT=.*|FESS_PORT=${FESS_PORT}|" /etc/default/fess
+fi
+
+if [[ "x${FESS_HEAP_SIZE}" != "x" ]] ; then
+  sed -i -e "s|^FESS_HEAP_SIZE=.*|FESS_HEAP_SIZE=${FESS_HEAP_SIZE}|" /etc/default/fess
+fi
+
+if [[ "x${SEARCH_ENGINE_HTTP_URL}" != "x" ]] ; then
+  sed -i -e "s|^SEARCH_ENGINE_HTTP_URL=.*|SEARCH_ENGINE_HTTP_URL=${SEARCH_ENGINE_HTTP_URL}|" /etc/default/fess
+elif [[ "x${ES_HTTP_URL}" != "x" ]] ; then
+  print_log WARN "ES_HTTP_URL is deprecated."
+  sed -i -e "s|^SEARCH_ENGINE_HTTP_URL=.*|SEARCH_ENGINE_HTTP_URL=${ES_HTTP_URL}|" /etc/default/fess
+else
+  SEARCH_ENGINE_HTTP_URL=http://localhost:9200
+fi
+
+if [[ "x${SEARCH_ENGINE_TYPE}" != "x" ]] ; then
+  FESS_JAVA_OPTS="${FESS_JAVA_OPTS} -Dfess.config.search_engine.type=${SEARCH_ENGINE_TYPE}"
+elif [[ "x${ES_TYPE}" != "x" ]] ; then
+  print_log WARN "ES_TYPE is deprecated."
+  FESS_JAVA_OPTS="${FESS_JAVA_OPTS} -Dfess.config.search_engine.type=${ES_TYPE}"
+fi
+
+if [[ "x${SEARCH_ENGINE_USERNAME}" != "x" ]] ; then
+  FESS_JAVA_OPTS="${FESS_JAVA_OPTS} -Dfess.config.search_engine.username=${SEARCH_ENGINE_USERNAME}"
+elif [[ "x${ES_USERNAME}" != "x" ]] ; then
+  print_log WARN "ES_USERNAME is deprecated."
+  FESS_JAVA_OPTS="${FESS_JAVA_OPTS} -Dfess.config.search_engine.username=${ES_USERNAME}"
+fi
+
+if [[ "x${SEARCH_ENGINE_PASSWORD}" != "x" ]] ; then
+  FESS_JAVA_OPTS="${FESS_JAVA_OPTS} -Dfess.config.search_engine.password=${SEARCH_ENGINE_PASSWORD}"
+elif [[ "x${ES_PASSWORD}" != "x" ]] ; then
+  print_log WARN "ES_PASSWORD is deprecated."
+  FESS_JAVA_OPTS="${FESS_JAVA_OPTS} -Dfess.config.search_engine.password=${ES_PASSWORD}"
+fi
+
+if [[ "x${FESS_JAVA_OPTS}" != "x" ]] ; then
+  echo "FESS_JAVA_OPTS=\"${FESS_JAVA_OPTS}\"" >> /etc/default/fess
+fi
+
+if [[ "x${PING_RETRIES}" = "x" ]] ; then
+  PING_RETRIES=3
+fi
+
+if [[ "x${PING_INTERVAL}" = "x" ]] ; then
+  PING_INTERVAL=60
+fi
+
+download_plugin() {
+  plugin_id=$1
+  plugin_name=$(echo ${plugin_id} | sed -e "s/:.*//")
+  plugin_version=$(echo ${plugin_id} | sed -e "s/.*://")
+  if [[ ${plugin_name} == fess-ds-* ]] \
+    || [[ ${plugin_name} == fess-ingest-* ]] \
+    || [[ ${plugin_name} == fess-script-* ]] \
+    || [[ ${plugin_name} == fess-llm-* ]] \
+    || [[ ${plugin_name} == fess-theme-* ]] \
+    || [[ ${plugin_name} == fess-webapp-* ]] \
+    ; then
+    plugin_file="${plugin_name}-${plugin_version}.jar"
+    if [[ ${plugin_version} == *-SNAPSHOT ]] ; then
+      metadata_file="${temp_dir}/maven-metadata.$$"
+      metadata_url="https://oss.sonatype.org/content/repositories/snapshots/org/codelibs/fess/${plugin_name}/${plugin_version}/maven-metadata.xml"
+      if ! curl -fs -o "${metadata_file}" "${metadata_url}" ; then
+        print_log ERROR "Failed to download from ${metadata_url}."
+        return
+      fi
+      version_timestamp=$(cat ${metadata_file} | grep "<timestamp>" | head -n1 | sed -e "s,.*timestamp>\(.*\)</timestamp.*,\1,")
+      version_buildnum=$(cat ${metadata_file} | grep "<buildNumber>" | head -n1 | sed -e "s,.*buildNumber>\(.*\)</buildNumber.*,\1,")
+      rm -f ${metadata_file}
+      plugin_file=$(echo ${plugin_file} | sed -e "s/SNAPSHOT/${version_timestamp}-${version_buildnum}/")
+      plugin_url="https://oss.sonatype.org/content/repositories/snapshots/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
+    else
+      plugin_url="https://repo.maven.apache.org/maven2/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
+    fi
+    print_log INFO "Downloading from ${plugin_url}"
+    if ! curl -fs -o "${temp_dir}/${plugin_file}" "${plugin_url}" > /dev/null; then
+      print_log ERROR "Failed to download ${plugin_file}."
+      return
+    fi
+    if ! curl -fs -o "${temp_dir}/${plugin_file}.sha1" "${plugin_url}.sha1" > /dev/null; then
+      print_log ERROR "Failed to download ${plugin_file}.sha1."
+      return
+    fi
+    if ! echo "$(cat "${temp_dir}/${plugin_file}.sha1") ${temp_dir}/${plugin_file}" | sha1sum -c > /dev/null ; then
+      print_log ERROR "Invalid checksum for ${plugin_file}."
+      return
+    fi
+    print_log INFO "Installing ${plugin_file}"
+    rm -f "${temp_dir}/${plugin_file}.sha1"
+    mv "${temp_dir}/${plugin_file}" "${plugin_dir}"
+    chown fess:fess "${plugin_dir}/${plugin_file}"
+  fi
+}
+
+start_fess() {
+  rm -f /usr/bin/java
+  ln -s /opt/java/openjdk/bin/java /usr/bin/java
+  touch /var/log/fess/fess-crawler.log \
+        /var/log/fess/fess-llm.log \
+        /var/log/fess/fess-suggest.log \
+        /var/log/fess/fess-thumbnail.log \
+        /var/log/fess/fess-urls.log \
+        /var/log/fess/audit.log \
+        /var/log/fess/fess.log
+  chown fess:fess /var/log/fess/fess-crawler.log \
+                  /var/log/fess/fess-llm.log \
+                  /var/log/fess/fess-suggest.log \
+                  /var/log/fess/fess-thumbnail.log \
+                  /var/log/fess/fess-urls.log \
+                  /var/log/fess/audit.log \
+                  /var/log/fess/fess.log
+  tail -qF /var/log/fess/fess-crawler.log /var/log/fess/fess-llm.log /var/log/fess/fess-suggest.log /var/log/fess/fess-thumbnail.log /var/log/fess/fess.log /var/log/fess/audit.log 2>/dev/null &
+  print_log INFO "Starting Fess service."
+  /etc/init.d/fess start > /dev/null 2>&1
+}
+
+wait_app() {
+  if [[ "x${FESS_CONTEXT_PATH}" = "x" ]] ; then
+    ping_path=/api/v2/health
+  else
+    ping_path=${FESS_CONTEXT_PATH}/api/v2/health
+  fi
+  while true ; do
+    status=$(curl -w '%{http_code}\n' -s -o /dev/null "http://localhost:8080${ping_path}")
+    if [[ x"${status}" = x200 ]] ; then
+      error_count=0
+    else
+      error_count=$((error_count + 1))
+    fi
+    if [[ ${error_count} -ge ${PING_RETRIES} ]] ; then
+      print_log ERROR "Fess is not available."
+      exit 1
+    fi
+    sleep ${PING_INTERVAL}
+  done
+}
+
+for plugin_id in $FESS_PLUGINS ; do
+  download_plugin $(echo ${plugin_id} | sed -e "s,/,,g")
+done
+
+start_fess
+
+if [[ "x${RUN_SHELL}" = "xtrue" ]] ; then
+  /bin/bash
+else
+  wait_app
+fi

--- a/fess/15.8/Dockerfile
+++ b/fess/15.8/Dockerfile
@@ -1,0 +1,93 @@
+# Base image with Java 21 JRE on Alpine
+FROM eclipse-temurin:21-jre-alpine
+
+# Metadata labels for better container management
+LABEL maintainer="CodeLibs" \
+      org.opencontainers.image.title="Fess" \
+      org.opencontainers.image.description="Enterprise search server powered by OpenSearch" \
+      org.opencontainers.image.url="https://fess.codelibs.org/" \
+      org.opencontainers.image.source="https://github.com/codelibs/docker-fess" \
+      org.opencontainers.image.vendor="CodeLibs" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+# Set environment variable for Fess application type
+ENV FESS_APP_TYPE=docker
+
+# Set Fess version as a build argument
+ARG FESS_VERSION=15.8.0
+
+# This ARG is used to bust the cache when needed
+ARG CACHEBUST=1
+
+# Combine RUN instructions to reduce image layers and size
+RUN set -x && \
+    # 1. Install minimal dependencies (including unzip for extraction)
+    apk add --no-cache \
+        bash \
+        curl \
+        coreutils \
+        unzip && \
+    # 2. Create a dedicated user and group for Fess
+    addgroup -g 1001 fess && \
+    adduser -u 1001 -G fess -S -h /var/lib/fess fess && \
+    # 3. Download and verify Fess package (zip version)
+    curl -LfsSo /tmp/fess-${FESS_VERSION}.zip \
+      https://github.com/codelibs/fess/releases/download/fess-${FESS_VERSION}/fess-${FESS_VERSION}.zip && \
+    # Note: Checksum verification would be ideal but snapshot builds may not have published checksums
+    # Verify download by checking file size is reasonable (>10MB for a valid Fess distribution)
+    [ $(stat -c%s /tmp/fess-${FESS_VERSION}.zip) -gt 10485760 ] || (echo "Downloaded file too small, likely corrupted" && exit 1) && \
+    # 4. Extract Fess archive
+    unzip -q /tmp/fess-${FESS_VERSION}.zip -d /opt && \
+    mv /opt/fess-${FESS_VERSION} /usr/share/fess && \
+    rm -f /tmp/fess-${FESS_VERSION}.zip && \
+    # 5. Remove unzip after use to keep image minimal
+    apk del unzip && \
+    # 6. Create necessary directories
+    mkdir -p /etc/default /etc/fess /opt/fess /var/tmp/fess /var/log/fess /var/lib/fess && \
+    # 7. Uncomment logging configurations in log4j2.xml files for console output
+    for f in $(find /usr/share/fess/app/WEB-INF/ -type f | grep log4j2.xml) ; do \
+      sed -i 's/[^\t]*<!-- //' $f; sed -i 's/\/> -->/\/>/' $f; done  && \
+    # 8. Configure Fess to load custom configurations from /opt/fess
+    sed -i -e 's#FESS_CLASSPATH="$FESS_CONF_PATH:$FESS_CLASSPATH"#FESS_CLASSPATH="$FESS_OVERRIDE_CONF_PATH:$FESS_CONF_PATH:$FESS_CLASSPATH"#g' /usr/share/fess/bin/fess && \
+    # 9. Create /etc/default/fess
+    echo "FESS_CONF_PATH=/etc/fess" >> /etc/default/fess && \
+    echo "FESS_OVERRIDE_CONF_PATH=/opt/fess" >> /etc/default/fess && \
+    echo "FESS_TEMP_PATH=/var/tmp/fess" >> /etc/default/fess && \
+    echo "FESS_LOG_PATH=/var/log/fess" >> /etc/default/fess && \
+    echo "FESS_VAR_PATH=/var/lib/fess" >> /etc/default/fess && \
+    echo "FESS_PORT=8080" >> /etc/default/fess && \
+    echo "FESS_HEAP_SIZE=512m" >> /etc/default/fess && \
+    echo "FESS_DICTIONARY_PATH=/var/lib/opensearch/config/" >> /etc/default/fess && \
+    echo "SEARCH_ENGINE_HOME=/usr/share/opensearch/" >> /etc/default/fess && \
+    echo "SEARCH_ENGINE_HTTP_URL=http://localhost:9200" >> /etc/default/fess && \
+    echo "export FESS_CONF_PATH FESS_OVERRIDE_CONF_PATH FESS_TEMP_PATH FESS_LOG_PATH FESS_VAR_PATH FESS_PORT FESS_HEAP_SIZE FESS_DICTIONARY_PATH SEARCH_ENGINE_HOME SEARCH_ENGINE_HTTP_URL" >> /etc/default/fess && \
+    # 10. Create and copy configuration files
+    touch /etc/fess/system.properties && \
+    mv /usr/share/fess/lib/classes/tomcat_config.properties \
+       /usr/share/fess/lib/classes/logging.properties \
+       /usr/share/fess/app/WEB-INF/classes/fess_config.properties \
+       /usr/share/fess/app/WEB-INF/classes/fess_env_*.properties \
+       /usr/share/fess/app/WEB-INF/classes/tika.xml \
+       /etc/fess && \
+    # 11. Set proper ownership for all Fess-related directories and files
+    chown -R fess:fess /usr/share/fess /etc/default/fess /etc/fess /opt/fess /var/tmp/fess /var/log/fess /var/lib/fess
+
+# Set working directory
+WORKDIR /usr/share/fess
+
+# Expose Fess port
+EXPOSE 8080
+
+# Copy the startup script into the container and set permissions
+COPY run.sh /usr/share/fess/run.sh
+RUN chmod +x /usr/share/fess/run.sh
+
+# Add health check to monitor container health
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+    CMD curl -f http://localhost:8080/api/v2/health || exit 1
+
+# The entrypoint script `run.sh` performs setup tasks that require root.
+# Therefore, the container must be started as root.
+# The script itself is responsible for starting the Fess process.
+USER root
+ENTRYPOINT ["/usr/share/fess/run.sh"]

--- a/fess/15.8/run.sh
+++ b/fess/15.8/run.sh
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+temp_dir=/tmp
+plugin_dir=/usr/share/fess/app/WEB-INF/plugin
+
+print_log() {
+  log_level=$1
+  message=$2
+  echo '{"@timestamp":"'$(date -u "+%Y-%m-%dT%H:%M:%S.%3NZ")'","log.level": "'${log_level}'","message":"'"${message}"'", "ecs.version": "1.2.0","service.name":"fess","event.dataset":"app","process.thread.name":"bootstrap","log.logger":"run.sh"}'
+}
+
+if [[ "x${FESS_DICTIONARY_PATH}" != "x" ]] ; then
+  sed -i -e "s|^FESS_DICTIONARY_PATH=.*|FESS_DICTIONARY_PATH=${FESS_DICTIONARY_PATH}|" /etc/default/fess
+fi
+
+if [[ "x${FESS_PORT}" != "x" ]] ; then
+  sed -i -e "s|^FESS_PORT=.*|FESS_PORT=${FESS_PORT}|" /etc/default/fess
+fi
+
+if [[ "x${FESS_HEAP_SIZE}" != "x" ]] ; then
+  sed -i -e "s|^FESS_HEAP_SIZE=.*|FESS_HEAP_SIZE=${FESS_HEAP_SIZE}|" /etc/default/fess
+fi
+
+if [[ "x${SEARCH_ENGINE_HTTP_URL}" != "x" ]] ; then
+  sed -i -e "s|^SEARCH_ENGINE_HTTP_URL=.*|SEARCH_ENGINE_HTTP_URL=${SEARCH_ENGINE_HTTP_URL}|" /etc/default/fess
+elif [[ "x${ES_HTTP_URL}" != "x" ]] ; then
+  print_log WARN "ES_HTTP_URL is deprecated."
+  sed -i -e "s|^SEARCH_ENGINE_HTTP_URL=.*|SEARCH_ENGINE_HTTP_URL=${ES_HTTP_URL}|" /etc/default/fess
+else
+  SEARCH_ENGINE_HTTP_URL=http://localhost:9200
+fi
+
+if [[ "x${SEARCH_ENGINE_TYPE}" != "x" ]] ; then
+  FESS_JAVA_OPTS="${FESS_JAVA_OPTS} -Dfess.config.search_engine.type=${SEARCH_ENGINE_TYPE}"
+elif [[ "x${ES_TYPE}" != "x" ]] ; then
+  print_log WARN "ES_TYPE is deprecated."
+  FESS_JAVA_OPTS="${FESS_JAVA_OPTS} -Dfess.config.search_engine.type=${ES_TYPE}"
+fi
+
+if [[ "x${SEARCH_ENGINE_USERNAME}" != "x" ]] ; then
+  FESS_JAVA_OPTS="${FESS_JAVA_OPTS} -Dfess.config.search_engine.username=${SEARCH_ENGINE_USERNAME}"
+elif [[ "x${ES_USERNAME}" != "x" ]] ; then
+  print_log WARN "ES_USERNAME is deprecated."
+  FESS_JAVA_OPTS="${FESS_JAVA_OPTS} -Dfess.config.search_engine.username=${ES_USERNAME}"
+fi
+
+if [[ "x${SEARCH_ENGINE_PASSWORD}" != "x" ]] ; then
+  FESS_JAVA_OPTS="${FESS_JAVA_OPTS} -Dfess.config.search_engine.password=${SEARCH_ENGINE_PASSWORD}"
+elif [[ "x${ES_PASSWORD}" != "x" ]] ; then
+  print_log WARN "ES_PASSWORD is deprecated."
+  FESS_JAVA_OPTS="${FESS_JAVA_OPTS} -Dfess.config.search_engine.password=${ES_PASSWORD}"
+fi
+
+if [[ "x${FESS_JAVA_OPTS}" != "x" ]] ; then
+  echo "FESS_JAVA_OPTS=\"${FESS_JAVA_OPTS}\"" >> /etc/default/fess
+fi
+
+if [[ "x${PING_RETRIES}" = "x" ]] ; then
+  PING_RETRIES=3
+fi
+
+if [[ "x${PING_INTERVAL}" = "x" ]] ; then
+  PING_INTERVAL=60
+fi
+
+download_plugin() {
+  plugin_id=$1
+  plugin_name=$(echo ${plugin_id} | sed -e "s/:.*//")
+  plugin_version=$(echo ${plugin_id} | sed -e "s/.*://")
+  if [[ ${plugin_name} == fess-ds-* ]] \
+    || [[ ${plugin_name} == fess-ingest-* ]] \
+    || [[ ${plugin_name} == fess-script-* ]] \
+    || [[ ${plugin_name} == fess-llm-* ]] \
+    || [[ ${plugin_name} == fess-theme-* ]] \
+    || [[ ${plugin_name} == fess-webapp-* ]] \
+    ; then
+    plugin_file="${plugin_name}-${plugin_version}.jar"
+    if [[ ${plugin_version} == *-SNAPSHOT ]] ; then
+      metadata_file="${temp_dir}/maven-metadata.$$"
+      metadata_url="https://oss.sonatype.org/content/repositories/snapshots/org/codelibs/fess/${plugin_name}/${plugin_version}/maven-metadata.xml"
+      if ! curl -fs -o "${metadata_file}" "${metadata_url}" ; then
+        print_log ERROR "Failed to download from ${metadata_url}."
+        return
+      fi
+      version_timestamp=$(cat ${metadata_file} | grep "<timestamp>" | head -n1 | sed -e "s,.*timestamp>\(.*\)</timestamp.*,\1,")
+      version_buildnum=$(cat ${metadata_file} | grep "<buildNumber>" | head -n1 | sed -e "s,.*buildNumber>\(.*\)</buildNumber.*,\1,")
+      rm -f ${metadata_file}
+      plugin_file=$(echo ${plugin_file} | sed -e "s/SNAPSHOT/${version_timestamp}-${version_buildnum}/")
+      plugin_url="https://oss.sonatype.org/content/repositories/snapshots/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
+    else
+      plugin_url="https://repo.maven.apache.org/maven2/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
+    fi
+    print_log INFO "Downloading from ${plugin_url}"
+    if ! curl -fs -o "${temp_dir}/${plugin_file}" "${plugin_url}" > /dev/null; then
+      print_log ERROR "Failed to download ${plugin_file}."
+      return
+    fi
+    if ! curl -fs -o "${temp_dir}/${plugin_file}.sha1" "${plugin_url}.sha1" > /dev/null; then
+      print_log ERROR "Failed to download ${plugin_file}.sha1."
+      return
+    fi
+    if ! echo "$(cat "${temp_dir}/${plugin_file}.sha1") ${temp_dir}/${plugin_file}" | sha1sum -c > /dev/null ; then
+      print_log ERROR "Invalid checksum for ${plugin_file}."
+      return
+    fi
+    print_log INFO "Installing ${plugin_file}"
+    rm -f "${temp_dir}/${plugin_file}.sha1"
+    mv "${temp_dir}/${plugin_file}" "${plugin_dir}"
+    chown fess:fess "${plugin_dir}/${plugin_file}"
+  fi
+}
+
+start_fess() {
+  rm -f /usr/bin/java
+  ln -s /opt/java/openjdk/bin/java /usr/bin/java
+  touch /var/log/fess/fess-crawler.log \
+        /var/log/fess/fess-llm.log \
+        /var/log/fess/fess-suggest.log \
+        /var/log/fess/fess-thumbnail.log \
+        /var/log/fess/fess-urls.log \
+        /var/log/fess/audit.log \
+        /var/log/fess/fess.log
+  chown fess:fess /var/log/fess/fess-crawler.log \
+                  /var/log/fess/fess-llm.log \
+                  /var/log/fess/fess-suggest.log \
+                  /var/log/fess/fess-thumbnail.log \
+                  /var/log/fess/fess-urls.log \
+                  /var/log/fess/audit.log \
+                  /var/log/fess/fess.log
+  tail -qF /var/log/fess/fess-crawler.log /var/log/fess/fess-llm.log /var/log/fess/fess-suggest.log /var/log/fess/fess-thumbnail.log /var/log/fess/fess.log /var/log/fess/audit.log 2>/dev/null &
+  print_log INFO "Starting Fess service."
+  # Start Fess directly since Alpine doesn't have init.d
+  su -s /bin/bash -c "source /etc/default/fess && cd /usr/share/fess && ./bin/fess" fess &
+}
+
+wait_app() {
+  if [[ "x${FESS_CONTEXT_PATH}" = "x" ]] ; then
+    ping_path=/api/v2/health
+  else
+    ping_path=${FESS_CONTEXT_PATH}/api/v2/health
+  fi
+  while true ; do
+    status=$(curl -w '%{http_code}\n' -s -o /dev/null "http://localhost:8080${ping_path}")
+    if [[ x"${status}" = x200 ]] ; then
+      error_count=0
+    else
+      error_count=$((error_count + 1))
+    fi
+    if [[ ${error_count} -ge ${PING_RETRIES} ]] ; then
+      print_log ERROR "Fess is not available."
+      exit 1
+    fi
+    sleep ${PING_INTERVAL}
+  done
+}
+
+for plugin_id in $FESS_PLUGINS ; do
+  download_plugin $(echo ${plugin_id} | sed -e "s,/,,g")
+done
+
+start_fess
+
+if [[ "x${RUN_SHELL}" = "xtrue" ]] ; then
+  /bin/bash
+else
+  wait_app
+fi


### PR DESCRIPTION
## Summary

Fess 15.8.0 has been released, so this adds the corresponding Docker image
directories and points the Compose configurations at the new version.

- Add `fess/15.8`, `fess/15.8-al2023`, and `fess/15.8-noble`, copied from the
  matching `snapshot*` directories with `FESS_VERSION` pinned to `15.8.0` and
  the package URL switched from the snapshot site to the GitHub release assets
  (`zip` / `rpm` / `deb`). Apart from the version number, the new files are
  identical to the `15.7*` ones.
- Bump the Fess image tag and the plugin versions from `15.7.0` to `15.8.0` in
  `compose/compose.yaml`, `compose/vanilla/compose.yaml`,
  `compose/multi-instance/compose-fess0{1,2}.yaml`,
  `compose/playwright/Dockerfile`, and the Gemini / OpenAI / Ollama overlays.
- Update the README build examples, project structure, and version matrix; the
  new matrix row records OpenSearch 3.8.0, which is the version Fess 15.8.0 is
  built against (`opensearch.version` in `fess-parent` 15.8.0).

## Verification

- `docker build ./fess/15.8/` completes successfully; the resulting image
  contains the 15.8.0 artifacts (`fess-crawler-15.8.0.jar`, etc.).
- All three release assets referenced by the Dockerfiles return HTTP 200 and are
  well above the size guards (~475 MB each).
- `docker compose config` passes for `compose.yaml` + `compose-opensearch3.yaml`,
  the three LLM overlays, and the multi-instance stack.

## Notes

- The 15.8.0 plugin JARs (`fess-llm-*`, `fess-webapp-semantic-search`,
  `fess-ds-wikipedia`) are not on Maven Central yet, so the LLM overlays will not
  be able to install plugins until they are published. This matches how the
  previous release was handled.
- Bumping `fess/snapshot*` to the next development version is left for a separate
  change, as before.
