### PR TITLE
chore(fess): bump snapshot Fess version to 15.9.0-SNAPSHOT

### DIFF
--- a/fess/snapshot-al2023/Dockerfile
+++ b/fess/snapshot-al2023/Dockerfile
@@ -14,7 +14,7 @@ LABEL maintainer="CodeLibs" \
 ENV FESS_APP_TYPE=docker
 
 # Set Fess version as a build argument
-ARG FESS_VERSION=15.8.1-SNAPSHOT
+ARG FESS_VERSION=15.9.0-SNAPSHOT
 
 # This ARG is used to bust the cache when needed
 ARG CACHEBUST=1

--- a/fess/snapshot-noble/Dockerfile
+++ b/fess/snapshot-noble/Dockerfile
@@ -14,7 +14,7 @@ LABEL maintainer="CodeLibs" \
 ENV FESS_APP_TYPE=docker
 
 # Set Fess version as a build argument
-ARG FESS_VERSION=15.8.1-SNAPSHOT
+ARG FESS_VERSION=15.9.0-SNAPSHOT
 
 # This ARG is used to bust the cache when needed
 ARG CACHEBUST=1

--- a/fess/snapshot/Dockerfile
+++ b/fess/snapshot/Dockerfile
@@ -14,7 +14,7 @@ LABEL maintainer="CodeLibs" \
 ENV FESS_APP_TYPE=docker
 
 # Set Fess version as a build argument
-ARG FESS_VERSION=15.8.1-SNAPSHOT
+ARG FESS_VERSION=15.9.0-SNAPSHOT
 
 # This ARG is used to bust the cache when needed
 ARG CACHEBUST=1


### PR DESCRIPTION
## Summary

Bump `ARG FESS_VERSION` from `15.8.1-SNAPSHOT` to `15.9.0-SNAPSHOT` in the three snapshot images, following the version bump of Fess and its libraries to the 15.9.0 development cycle.

- `fess/snapshot/Dockerfile` (Alpine, zip)
- `fess/snapshot-noble/Dockerfile` (Ubuntu Noble, deb)
- `fess/snapshot-al2023/Dockerfile` (Amazon Linux 2023, rpm)

This is the routine per-cycle bump (previously #57 for 15.7.0-SNAPSHOT and #61 for 15.8.0-SNAPSHOT). Leaving the ARG pinned is silent: the old `15.8.1-SNAPSHOT` artifacts are still served, so the build keeps succeeding while shipping images built from before the version bump.

Only the snapshot images are touched. The stable references (`compose/*.yaml`, `fess/15.8*/`, `README.md`) still point at 15.8.0 and are updated when 15.9.0 is released.

## Test plan

Upstream artifacts are published (all three return HTTP 200, ~475 MB each, built right after the Fess version bump merged):

- `https://fess.codelibs.org/snapshot/fess-15.9.0-SNAPSHOT.zip`
- `https://fess.codelibs.org/snapshot/fess-15.9.0-SNAPSHOT.deb`
- `https://fess.codelibs.org/snapshot/fess-15.9.0-SNAPSHOT.rpm`

- [x] `docker build --no-cache ./fess/snapshot/` succeeds
- [x] The resulting image contains the expected 15.9.0-SNAPSHOT libraries:
      `fess-crawler-15.9.0-SNAPSHOT.jar`, `fess-crawler-lasta-15.9.0-SNAPSHOT.jar`,
      `fess-crawler-opensearch-15.9.0-SNAPSHOT.jar`,
      `fess-crawler-playwright-15.9.0-SNAPSHOT.jar`, `fess-suggest-15.9.0-SNAPSHOT.jar`
- [ ] `snapshot-noble` / `snapshot-al2023` differ only in package format (deb/rpm); both URLs verified available
