### PR TITLE
fix(fess): resolve plugins from maven.codelibs.org

### DIFF
--- a/fess/15.8-al2023/run.sh
+++ b/fess/15.8-al2023/run.sh
@@ -77,7 +77,7 @@ download_plugin() {
     plugin_file="${plugin_name}-${plugin_version}.jar"
     if [[ ${plugin_version} == *-SNAPSHOT ]] ; then
       metadata_file="${temp_dir}/maven-metadata.$$"
-      metadata_url="https://oss.sonatype.org/content/repositories/snapshots/org/codelibs/fess/${plugin_name}/${plugin_version}/maven-metadata.xml"
+      metadata_url="https://maven.codelibs.org/snapshot/org/codelibs/fess/${plugin_name}/${plugin_version}/maven-metadata.xml"
       if ! curl -fs -o "${metadata_file}" "${metadata_url}" ; then
         print_log ERROR "Failed to download from ${metadata_url}."
         return
@@ -86,9 +86,9 @@ download_plugin() {
       version_buildnum=$(cat ${metadata_file} | grep "<buildNumber>" | head -n1 | sed -e "s,.*buildNumber>\(.*\)</buildNumber.*,\1,")
       rm -f ${metadata_file}
       plugin_file=$(echo ${plugin_file} | sed -e "s/SNAPSHOT/${version_timestamp}-${version_buildnum}/")
-      plugin_url="https://oss.sonatype.org/content/repositories/snapshots/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
+      plugin_url="https://maven.codelibs.org/snapshot/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
     else
-      plugin_url="https://repo.maven.apache.org/maven2/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
+      plugin_url="https://maven.codelibs.org/release/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
     fi
     print_log INFO "Downloading from ${plugin_url}"
     if ! curl -fs -o "${temp_dir}/${plugin_file}" "${plugin_url}" > /dev/null; then

--- a/fess/15.8-noble/run.sh
+++ b/fess/15.8-noble/run.sh
@@ -77,7 +77,7 @@ download_plugin() {
     plugin_file="${plugin_name}-${plugin_version}.jar"
     if [[ ${plugin_version} == *-SNAPSHOT ]] ; then
       metadata_file="${temp_dir}/maven-metadata.$$"
-      metadata_url="https://oss.sonatype.org/content/repositories/snapshots/org/codelibs/fess/${plugin_name}/${plugin_version}/maven-metadata.xml"
+      metadata_url="https://maven.codelibs.org/snapshot/org/codelibs/fess/${plugin_name}/${plugin_version}/maven-metadata.xml"
       if ! curl -fs -o "${metadata_file}" "${metadata_url}" ; then
         print_log ERROR "Failed to download from ${metadata_url}."
         return
@@ -86,9 +86,9 @@ download_plugin() {
       version_buildnum=$(cat ${metadata_file} | grep "<buildNumber>" | head -n1 | sed -e "s,.*buildNumber>\(.*\)</buildNumber.*,\1,")
       rm -f ${metadata_file}
       plugin_file=$(echo ${plugin_file} | sed -e "s/SNAPSHOT/${version_timestamp}-${version_buildnum}/")
-      plugin_url="https://oss.sonatype.org/content/repositories/snapshots/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
+      plugin_url="https://maven.codelibs.org/snapshot/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
     else
-      plugin_url="https://repo.maven.apache.org/maven2/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
+      plugin_url="https://maven.codelibs.org/release/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
     fi
     print_log INFO "Downloading from ${plugin_url}"
     if ! curl -fs -o "${temp_dir}/${plugin_file}" "${plugin_url}" > /dev/null; then

--- a/fess/15.8/run.sh
+++ b/fess/15.8/run.sh
@@ -77,7 +77,7 @@ download_plugin() {
     plugin_file="${plugin_name}-${plugin_version}.jar"
     if [[ ${plugin_version} == *-SNAPSHOT ]] ; then
       metadata_file="${temp_dir}/maven-metadata.$$"
-      metadata_url="https://oss.sonatype.org/content/repositories/snapshots/org/codelibs/fess/${plugin_name}/${plugin_version}/maven-metadata.xml"
+      metadata_url="https://maven.codelibs.org/snapshot/org/codelibs/fess/${plugin_name}/${plugin_version}/maven-metadata.xml"
       if ! curl -fs -o "${metadata_file}" "${metadata_url}" ; then
         print_log ERROR "Failed to download from ${metadata_url}."
         return
@@ -86,9 +86,9 @@ download_plugin() {
       version_buildnum=$(cat ${metadata_file} | grep "<buildNumber>" | head -n1 | sed -e "s,.*buildNumber>\(.*\)</buildNumber.*,\1,")
       rm -f ${metadata_file}
       plugin_file=$(echo ${plugin_file} | sed -e "s/SNAPSHOT/${version_timestamp}-${version_buildnum}/")
-      plugin_url="https://oss.sonatype.org/content/repositories/snapshots/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
+      plugin_url="https://maven.codelibs.org/snapshot/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
     else
-      plugin_url="https://repo.maven.apache.org/maven2/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
+      plugin_url="https://maven.codelibs.org/release/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
     fi
     print_log INFO "Downloading from ${plugin_url}"
     if ! curl -fs -o "${temp_dir}/${plugin_file}" "${plugin_url}" > /dev/null; then

--- a/fess/snapshot-al2023/run.sh
+++ b/fess/snapshot-al2023/run.sh
@@ -77,7 +77,7 @@ download_plugin() {
     plugin_file="${plugin_name}-${plugin_version}.jar"
     if [[ ${plugin_version} == *-SNAPSHOT ]] ; then
       metadata_file="${temp_dir}/maven-metadata.$$"
-      metadata_url="https://oss.sonatype.org/content/repositories/snapshots/org/codelibs/fess/${plugin_name}/${plugin_version}/maven-metadata.xml"
+      metadata_url="https://maven.codelibs.org/snapshot/org/codelibs/fess/${plugin_name}/${plugin_version}/maven-metadata.xml"
       if ! curl -fs -o "${metadata_file}" "${metadata_url}" ; then
         print_log ERROR "Failed to download from ${metadata_url}."
         return
@@ -86,9 +86,9 @@ download_plugin() {
       version_buildnum=$(cat ${metadata_file} | grep "<buildNumber>" | head -n1 | sed -e "s,.*buildNumber>\(.*\)</buildNumber.*,\1,")
       rm -f ${metadata_file}
       plugin_file=$(echo ${plugin_file} | sed -e "s/SNAPSHOT/${version_timestamp}-${version_buildnum}/")
-      plugin_url="https://oss.sonatype.org/content/repositories/snapshots/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
+      plugin_url="https://maven.codelibs.org/snapshot/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
     else
-      plugin_url="https://repo.maven.apache.org/maven2/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
+      plugin_url="https://maven.codelibs.org/release/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
     fi
     print_log INFO "Downloading from ${plugin_url}"
     if ! curl -fs -o "${temp_dir}/${plugin_file}" "${plugin_url}" > /dev/null; then

--- a/fess/snapshot-noble/run.sh
+++ b/fess/snapshot-noble/run.sh
@@ -77,7 +77,7 @@ download_plugin() {
     plugin_file="${plugin_name}-${plugin_version}.jar"
     if [[ ${plugin_version} == *-SNAPSHOT ]] ; then
       metadata_file="${temp_dir}/maven-metadata.$$"
-      metadata_url="https://oss.sonatype.org/content/repositories/snapshots/org/codelibs/fess/${plugin_name}/${plugin_version}/maven-metadata.xml"
+      metadata_url="https://maven.codelibs.org/snapshot/org/codelibs/fess/${plugin_name}/${plugin_version}/maven-metadata.xml"
       if ! curl -fs -o "${metadata_file}" "${metadata_url}" ; then
         print_log ERROR "Failed to download from ${metadata_url}."
         return
@@ -86,9 +86,9 @@ download_plugin() {
       version_buildnum=$(cat ${metadata_file} | grep "<buildNumber>" | head -n1 | sed -e "s,.*buildNumber>\(.*\)</buildNumber.*,\1,")
       rm -f ${metadata_file}
       plugin_file=$(echo ${plugin_file} | sed -e "s/SNAPSHOT/${version_timestamp}-${version_buildnum}/")
-      plugin_url="https://oss.sonatype.org/content/repositories/snapshots/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
+      plugin_url="https://maven.codelibs.org/snapshot/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
     else
-      plugin_url="https://repo.maven.apache.org/maven2/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
+      plugin_url="https://maven.codelibs.org/release/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
     fi
     print_log INFO "Downloading from ${plugin_url}"
     if ! curl -fs -o "${temp_dir}/${plugin_file}" "${plugin_url}" > /dev/null; then

--- a/fess/snapshot/run.sh
+++ b/fess/snapshot/run.sh
@@ -73,7 +73,7 @@ download_plugin() {
     plugin_file="${plugin_name}-${plugin_version}.jar"
     if [[ ${plugin_version} == *-SNAPSHOT ]] ; then
       metadata_file="${temp_dir}/maven-metadata.$$"
-      metadata_url="https://oss.sonatype.org/content/repositories/snapshots/org/codelibs/fess/${plugin_name}/${plugin_version}/maven-metadata.xml"
+      metadata_url="https://maven.codelibs.org/snapshot/org/codelibs/fess/${plugin_name}/${plugin_version}/maven-metadata.xml"
       if ! curl -fs -o "${metadata_file}" "${metadata_url}" ; then
         print_log ERROR "Failed to download from ${metadata_url}."
         return
@@ -82,9 +82,9 @@ download_plugin() {
       version_buildnum=$(cat ${metadata_file} | grep "<buildNumber>" | head -n1 | sed -e "s,.*buildNumber>\(.*\)</buildNumber.*,\1,")
       rm -f ${metadata_file}
       plugin_file=$(echo ${plugin_file} | sed -e "s/SNAPSHOT/${version_timestamp}-${version_buildnum}/")
-      plugin_url="https://oss.sonatype.org/content/repositories/snapshots/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
+      plugin_url="https://maven.codelibs.org/snapshot/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
     else
-      plugin_url="https://repo.maven.apache.org/maven2/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
+      plugin_url="https://maven.codelibs.org/release/org/codelibs/fess/${plugin_name}/${plugin_version}/${plugin_file}"
     fi
     print_log INFO "Downloading from ${plugin_url}"
     if ! curl -fs -o "${temp_dir}/${plugin_file}" "${plugin_url}" > /dev/null; then


### PR DESCRIPTION
`FESS_PLUGINS` cannot install any plugin from 15.8.0 onwards, and it fails silently.

## The problem

`download_plugin()` hardcodes the artifact URLs rather than using the `plugin.repositories` configuration, and both hosts it points at are wrong for Fess plugins:

| version form | hardcoded host | state |
|---|---|---|
| release | `repo.maven.apache.org` | Fess plugins are not published to Maven Central — they are released to `maven.codelibs.org/release` |
| `-SNAPSHOT` | `oss.sonatype.org` | OSSRH is retired; snapshots go to `maven.codelibs.org/snapshot` |

Plugin releases up to 15.7.0 are still on Maven Central, so this only bites from 15.8.0 on — but there it affects **every** plugin, not one. Spot-checked `fess-webapp-multimodal`, `fess-webapp-mcp`, `fess-llm-openai` and `fess-ds-git`: all stop at 15.7.0 on Central and have 15.8.0 only on codelibs.

## Why it is easy to miss

The failing branch ends in `return`, not `exit`. Fess therefore **starts without the plugin and the container still reports healthy**. The entire signal is one line in the boot log:

```
INFO  Downloading from https://repo.maven.apache.org/maven2/org/codelibs/fess/fess-webapp-multimodal/15.8.0/fess-webapp-multimodal-15.8.0.jar
ERROR Failed to download fess-webapp-multimodal-15.8.0.jar.
```

A stack can pass its own start-up checks in this state — anything the plugin merely *extends* (rather than provides outright) still looks correct, because the core half of it is present.

## The change

URLs only, no logic changes — the codelibs layout is already what this function expects:

- release serves the jar and its `.sha1`
- snapshot serves a `maven-metadata.xml` carrying `<timestamp>`/`<buildNumber>`, plus the timestamped jar and its `.sha1`

## Verification

Ran the patched download steps for both branches inside `ghcr.io/codelibs/fess:15.8.0-noble`:

- **release** — jar and `.sha1` fetched, `sha1sum -c` reports `OK`, jar installed
- **SNAPSHOT** — metadata resolved `timestamp=20260827.043612` / `buildNumber=3`, timestamped jar fetched, `sha1sum -c` reports `OK`

`bash -n` passes on all six modified scripts.

## Scope

Applied to the `15.8` and `snapshot` image variants (6 files). Older variants keep the Maven Central URL, which is still correct for the plugin versions of their generation.

Two things deliberately left out of this PR:

- The `snapshot` → `oss.sonatype.org` URL is dead in the older variants too. Their images are already published, so editing them changes nothing unless they are rebuilt.
- A download failure for an explicitly requested `FESS_PLUGINS` entry still lets start-up continue. Correcting the URLs removes the current cause, but a typo or an unreleased version would fail the same silent way. Whether that should abort start-up is a separate design decision.
