### PR TITLE
fix(fess): derive the health URL from FESS_PORT and FESS_CONTEXT_PATH

### DIFF
--- a/compose/compose.yaml
+++ b/compose/compose.yaml
@@ -20,7 +20,7 @@ services:
         max-size: "10m"
         max-file: "5"
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8080/api/v2/health || exit 1"]
+      test: ["CMD-SHELL", "curl -f \"http://localhost:$${FESS_PORT:-8080}$${FESS_CONTEXT_PATH%/}/api/v2/health\" || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/fess/snapshot-al2023/Dockerfile
+++ b/fess/snapshot-al2023/Dockerfile
@@ -64,7 +64,7 @@ RUN chmod +x /usr/share/fess/run.sh
 
 # Add health check to monitor container health
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
-    CMD curl -f http://localhost:8080/api/v2/health || exit 1
+    CMD curl -f "http://localhost:${FESS_PORT:-8080}${FESS_CONTEXT_PATH%/}/api/v2/health" || exit 1
 
 # The entrypoint script `run.sh` performs setup tasks that require root.
 # Therefore, the container must be started as root.

--- a/fess/snapshot-al2023/run.sh
+++ b/fess/snapshot-al2023/run.sh
@@ -134,13 +134,12 @@ start_fess() {
 }
 
 wait_app() {
-  if [[ "x${FESS_CONTEXT_PATH}" = "x" ]] ; then
-    ping_path=/api/v2/health
-  else
-    ping_path=${FESS_CONTEXT_PATH}/api/v2/health
-  fi
+  # Same variables Fess itself uses to bind the connector, so the supervisor
+  # follows a relocated port or context path. A bare "/" context path is the
+  # Fess default and must not become a double slash.
+  ping_url="http://localhost:${FESS_PORT:-8080}${FESS_CONTEXT_PATH%/}/api/v2/health"
   while true ; do
-    status=$(curl -w '%{http_code}\n' -s -o /dev/null "http://localhost:8080${ping_path}")
+    status=$(curl -w '%{http_code}\n' -s -o /dev/null "${ping_url}")
     if [[ x"${status}" = x200 ]] ; then
       error_count=0
     else

--- a/fess/snapshot-noble/Dockerfile
+++ b/fess/snapshot-noble/Dockerfile
@@ -68,7 +68,7 @@ RUN chmod +x /usr/share/fess/run.sh
 
 # Add health check to monitor container health
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
-    CMD curl -f http://localhost:8080/api/v2/health || exit 1
+    CMD curl -f "http://localhost:${FESS_PORT:-8080}${FESS_CONTEXT_PATH%/}/api/v2/health" || exit 1
 
 # The entrypoint script `run.sh` performs setup tasks that require root.
 # Therefore, the container must be started as root.

--- a/fess/snapshot-noble/run.sh
+++ b/fess/snapshot-noble/run.sh
@@ -133,13 +133,12 @@ start_fess() {
 }
 
 wait_app() {
-  if [[ "x${FESS_CONTEXT_PATH}" = "x" ]] ; then
-    ping_path=/api/v2/health
-  else
-    ping_path=${FESS_CONTEXT_PATH}/api/v2/health
-  fi
+  # Same variables Fess itself uses to bind the connector, so the supervisor
+  # follows a relocated port or context path. A bare "/" context path is the
+  # Fess default and must not become a double slash.
+  ping_url="http://localhost:${FESS_PORT:-8080}${FESS_CONTEXT_PATH%/}/api/v2/health"
   while true ; do
-    status=$(curl -w '%{http_code}\n' -s -o /dev/null "http://localhost:8080${ping_path}")
+    status=$(curl -w '%{http_code}\n' -s -o /dev/null "${ping_url}")
     if [[ x"${status}" = x200 ]] ; then
       error_count=0
     else

--- a/fess/snapshot/Dockerfile
+++ b/fess/snapshot/Dockerfile
@@ -85,7 +85,7 @@ RUN chmod +x /usr/share/fess/run.sh
 
 # Add health check to monitor container health
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
-    CMD curl -f http://localhost:8080/api/v2/health || exit 1
+    CMD curl -f "http://localhost:${FESS_PORT:-8080}${FESS_CONTEXT_PATH%/}/api/v2/health" || exit 1
 
 # The entrypoint script `run.sh` performs setup tasks that require root.
 # Therefore, the container must be started as root.

--- a/fess/snapshot/run.sh
+++ b/fess/snapshot/run.sh
@@ -130,13 +130,12 @@ start_fess() {
 }
 
 wait_app() {
-  if [[ "x${FESS_CONTEXT_PATH}" = "x" ]] ; then
-    ping_path=/api/v2/health
-  else
-    ping_path=${FESS_CONTEXT_PATH}/api/v2/health
-  fi
+  # Same variables Fess itself uses to bind the connector, so the supervisor
+  # follows a relocated port or context path. A bare "/" context path is the
+  # Fess default and must not become a double slash.
+  ping_url="http://localhost:${FESS_PORT:-8080}${FESS_CONTEXT_PATH%/}/api/v2/health"
   while true ; do
-    status=$(curl -w '%{http_code}\n' -s -o /dev/null "http://localhost:8080${ping_path}")
+    status=$(curl -w '%{http_code}\n' -s -o /dev/null "${ping_url}")
     if [[ x"${status}" = x200 ]] ; then
       error_count=0
     else


### PR DESCRIPTION
The container HEALTHCHECK and the supervisor loop in run.sh both asked for
http://localhost:8080/api/v2/health with the port and path written out
literally, while Fess binds its connector from FESS_PORT and
FESS_CONTEXT_PATH. Either variable therefore worked as far as Fess was
concerned and then killed the container that was serving correctly.

With FESS_PORT=9099 Fess answers 200 on 9099, the probe cannot connect to
8080, the container is reported unhealthy, and run.sh gives up with "Fess
is not available." and exits. FESS_CONTEXT_PATH tells the same story:
/fess/api/v2/health returns 200 while the probe asks for /api/v2/health
and is given 404. wait_app() already assembled the path from
FESS_CONTEXT_PATH, so only the port was missing there; the HEALTHCHECK had
neither.

Build the URL from ${FESS_PORT:-8080} and ${FESS_CONTEXT_PATH%/} in both
places. Stripping one trailing slash matters because "/" is the Fess
default for the context path and would otherwise yield a double slash. The
Compose healthcheck override carries the same expression escaped as $$, so
Compose hands it to the container shell instead of interpolating it from
the host environment.

Verified with a locally built snapshot image against OpenSearch 3.8.
FESS_PORT=9099 and FESS_CONTEXT_PATH=/fess each reach healthy with
restarts=0 and no "Fess is not available." line, where the same image
without the change ends exited and unhealthy inside a minute; a container
with neither variable set still reaches healthy on the default port. The
Compose escaping was checked on its own: a host FESS_PORT does not leak
into the rendered command, and the container's own values produce the
expected URL with the trailing slash removed.

Applied to the snapshot variants only, since the released images are
already published and are not rebuilt.

