### PR TITLE
fix(fess): report unrecognized FESS_PLUGINS entries

### DIFF
--- a/fess/snapshot-al2023/run.sh
+++ b/fess/snapshot-al2023/run.sh
@@ -107,6 +107,8 @@ download_plugin() {
     rm -f "${temp_dir}/${plugin_file}.sha1"
     mv "${temp_dir}/${plugin_file}" "${plugin_dir}"
     chown fess:fess "${plugin_dir}/${plugin_file}"
+  else
+    print_log ERROR "Unrecognized plugin ${plugin_id} in FESS_PLUGINS. Expected <name>:<version>, where <name> starts with fess-ds-, fess-ingest-, fess-llm-, fess-script-, fess-theme- or fess-webapp-. Skipping it."
   fi
 }
 

--- a/fess/snapshot-noble/run.sh
+++ b/fess/snapshot-noble/run.sh
@@ -107,6 +107,8 @@ download_plugin() {
     rm -f "${temp_dir}/${plugin_file}.sha1"
     mv "${temp_dir}/${plugin_file}" "${plugin_dir}"
     chown fess:fess "${plugin_dir}/${plugin_file}"
+  else
+    print_log ERROR "Unrecognized plugin ${plugin_id} in FESS_PLUGINS. Expected <name>:<version>, where <name> starts with fess-ds-, fess-ingest-, fess-llm-, fess-script-, fess-theme- or fess-webapp-. Skipping it."
   fi
 }
 

--- a/fess/snapshot/run.sh
+++ b/fess/snapshot/run.sh
@@ -103,6 +103,8 @@ download_plugin() {
     rm -f "${temp_dir}/${plugin_file}.sha1"
     mv "${temp_dir}/${plugin_file}" "${plugin_dir}"
     chown fess:fess "${plugin_dir}/${plugin_file}"
+  else
+    print_log ERROR "Unrecognized plugin ${plugin_id} in FESS_PLUGINS. Expected <name>:<version>, where <name> starts with fess-ds-, fess-ingest-, fess-llm-, fess-script-, fess-theme- or fess-webapp-. Skipping it."
   fi
 }
 


### PR DESCRIPTION
download_plugin() acted only on names carrying one of the known plugin
prefixes and had no else branch, so anything else was dropped without a
word. FESS_PLUGINS=notaplugin:15.9.0 produced no plugin-related log line at
all, and the container started and went healthy as though nothing had been
asked of it. A typo in a plugin name lands in exactly this branch and
leaves a Fess that looks correct while missing the data store, script
engine or theme the deployment was built around.

Add the missing else branch and log an ERROR that repeats the offending
entry and lists the recognized prefixes, so the line says what to correct
rather than only that something was wrong.

The entry is skipped rather than fatal. The same function already logs
"Failed to download ..." and starts anyway when the prefix is right and the
version is wrong, and a mistyped name does not deserve harsher treatment
than a mistyped version. Refusing to start would also turn any existing
FESS_PLUGINS value this list does not recognize into a crash loop the
moment the image is upgraded, which is a worse outcome than a loud line in
the boot log.

Verified with a locally built snapshot image against OpenSearch 3.8. With
FESS_PLUGINS set to an unrecognized name, a valid snapshot plugin and a
valid prefix carrying a version that does not exist, the boot log now
carries the new ERROR for the unrecognized name, downloads and installs the
valid plugin, still reports the failed download for the bad version, and
the container reaches healthy. The same input on the image without this
change produces no plugin-related line at all.

Applied to the snapshot variants only, since the released images are
already published and are not rebuilt.

