### PR TITLE
fix(fess): honor FESS_MIN_MEM and FESS_MAX_MEM

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,30 @@ environment:
   # Dictionary and data paths
   - FESS_DICTIONARY_PATH=/usr/share/opensearch/config/dictionary/
   
-  # Performance tuning
+  # Heap size (see Memory Settings below)
   - FESS_HEAP_SIZE=1g
-  - FESS_JAVA_OPTS=-server -Xms1g -Xmx1g
-  
+
+  # Extra JVM options. Do not put -Xms / -Xmx here.
+  - FESS_JAVA_OPTS=-Djavax.net.ssl.trustStore=/opt/fess/truststore.jks
+
   # Plugin installation
   - FESS_PLUGINS=fess-webapp-semantic-search:15.8.0 fess-ds-wikipedia:15.8.0
 ```
+
+#### Memory Settings
+
+The heap comes from `FESS_HEAP_SIZE`, or from the `FESS_MIN_MEM` / `FESS_MAX_MEM` pair when you want an asymmetric heap:
+
+| Variables | Resulting JVM flags |
+|-----------|---------------------|
+| `FESS_HEAP_SIZE=1g` | `-Xms1g -Xmx1g` |
+| `FESS_MIN_MEM=512m` and `FESS_MAX_MEM=2g` | `-Xms512m -Xmx2g` |
+| both of the above | `-Xms1g -Xmx1g`; `FESS_HEAP_SIZE` wins |
+| none of them | `-Xms512m -Xmx512m`, the container default |
+
+Set both halves of the pair. An unset half falls back to the Fess default (`256m` for the minimum, `2g` for the maximum), not to the container default.
+
+Do not pass `-Xms` or `-Xmx` through `FESS_JAVA_OPTS`. Fess appends the pair it derives from the variables above *after* everything in `FESS_JAVA_OPTS`, and the JVM keeps the last value it is given, so heap flags placed there are discarded without a warning.
 
 ### Multi-Instance Deployment
 
@@ -228,11 +245,17 @@ docker compose logs search01
 ```
 
 **Out of memory errors:**
-```bash
-# Increase heap size
-export FESS_HEAP_SIZE=2g
-docker compose up -d
+
+Raise the heap in the `environment:` block of the Fess service. Exporting the variable in your shell has no effect, because `compose.yaml` does not pass the host environment through:
+
+```yaml
+services:
+  fess01:
+    environment:
+      - "FESS_HEAP_SIZE=2g"
 ```
+
+Recreate the container afterwards so the new value is applied.
 
 **Search not working:**
 ```bash

--- a/fess/snapshot-al2023/run.sh
+++ b/fess/snapshot-al2023/run.sh
@@ -19,6 +19,11 @@ fi
 
 if [[ "x${FESS_HEAP_SIZE}" != "x" ]] ; then
   sed -i -e "s|^FESS_HEAP_SIZE=.*|FESS_HEAP_SIZE=${FESS_HEAP_SIZE}|" /etc/sysconfig/fess
+elif [[ "x${FESS_MIN_MEM}${FESS_MAX_MEM}" != "x" ]] ; then
+  # The packaged defaults file pins FESS_HEAP_SIZE and bin/fess.in.sh lets it
+  # win over FESS_MIN_MEM/FESS_MAX_MEM. Clear it so the pair is honored; the
+  # pair itself already reaches the JVM through the environment.
+  sed -i -e "s|^FESS_HEAP_SIZE=.*|FESS_HEAP_SIZE=|" /etc/sysconfig/fess
 fi
 
 if [[ "x${SEARCH_ENGINE_HTTP_URL}" != "x" ]] ; then

--- a/fess/snapshot-noble/run.sh
+++ b/fess/snapshot-noble/run.sh
@@ -19,6 +19,11 @@ fi
 
 if [[ "x${FESS_HEAP_SIZE}" != "x" ]] ; then
   sed -i -e "s|^FESS_HEAP_SIZE=.*|FESS_HEAP_SIZE=${FESS_HEAP_SIZE}|" /etc/default/fess
+elif [[ "x${FESS_MIN_MEM}${FESS_MAX_MEM}" != "x" ]] ; then
+  # The packaged defaults file pins FESS_HEAP_SIZE and bin/fess.in.sh lets it
+  # win over FESS_MIN_MEM/FESS_MAX_MEM. Clear it so the pair is honored; the
+  # pair itself already reaches the JVM through the environment.
+  sed -i -e "s|^FESS_HEAP_SIZE=.*|FESS_HEAP_SIZE=|" /etc/default/fess
 fi
 
 if [[ "x${SEARCH_ENGINE_HTTP_URL}" != "x" ]] ; then

--- a/fess/snapshot/Dockerfile
+++ b/fess/snapshot/Dockerfile
@@ -58,7 +58,9 @@ RUN set -x && \
     echo 'export FESS_LOG_PATH="${FESS_LOG_PATH:-/var/log/fess}"' >> /etc/default/fess && \
     echo 'export FESS_VAR_PATH="${FESS_VAR_PATH:-/var/lib/fess}"' >> /etc/default/fess && \
     echo 'export FESS_PORT="${FESS_PORT:-8080}"' >> /etc/default/fess && \
-    echo 'export FESS_HEAP_SIZE="${FESS_HEAP_SIZE:-512m}"' >> /etc/default/fess && \
+    #    bin/fess.in.sh lets FESS_HEAP_SIZE override FESS_MIN_MEM/FESS_MAX_MEM,
+    #    so the heap default is only applied when neither of the pair is given.
+    echo 'if [ -z "${FESS_MIN_MEM}${FESS_MAX_MEM}" ] ; then export FESS_HEAP_SIZE="${FESS_HEAP_SIZE:-512m}" ; fi' >> /etc/default/fess && \
     echo 'export FESS_DICTIONARY_PATH="${FESS_DICTIONARY_PATH:-/var/lib/opensearch/config/}"' >> /etc/default/fess && \
     echo 'export SEARCH_ENGINE_HOME="${SEARCH_ENGINE_HOME:-/usr/share/opensearch/}"' >> /etc/default/fess && \
     echo 'export SEARCH_ENGINE_HTTP_URL="${SEARCH_ENGINE_HTTP_URL:-http://localhost:9200}"' >> /etc/default/fess && \


### PR DESCRIPTION
bin/fess.in.sh takes FESS_MIN_MEM and FESS_MAX_MEM as the heap bounds and
lets FESS_HEAP_SIZE overwrite both when it is set. Every image pins
FESS_HEAP_SIZE to 512m unconditionally, so the pair could never take
effect: setting FESS_MIN_MEM=333m and FESS_MAX_MEM=999m still started the
JVM with -Xms512m -Xmx512m, with nothing in the log to say the values had
been discarded. On Alpine the pin is written by this repository into
/etc/default/fess; on the deb and rpm images it comes from the packaged
defaults file that run.sh already rewrites for FESS_HEAP_SIZE.

Apply the container heap default only when neither half of the pair is
present, and on the packaged images clear the pinned value in the defaults
file the init script sources. The pair itself needs no forwarding: it is
already in the container environment, and start-stop-daemon on the deb
image and the initscripts daemon function on the rpm image both hand that
environment to the JVM unchanged. The order is now an explicit
FESS_HEAP_SIZE first, then FESS_MIN_MEM/FESS_MAX_MEM, then the 512m
container default, so nothing an operator sets is thrown away silently.

The same fess.in.sh appends the derived -Xms/-Xmx after everything in
FESS_JAVA_OPTS, and the JVM keeps the last value, so the README's
"-server -Xms1g -Xmx1g" example was discarded in the same way. Replace it
with a JVM option that survives, describe the heap variables and their
order in a short table, and say plainly that -Xms and -Xmx do not belong in
FESS_JAVA_OPTS. The troubleshooting entry told readers to export
FESS_HEAP_SIZE in their shell, which the Compose file does not forward, so
it now shows the environment block to edit instead.

Verified on all three snapshot images by reading the heap flags out of the
running JVM's argv. The pair yields -Xms333m -Xmx999m where the published
image yields -Xms512m -Xmx512m for the same input; no heap variables still
yields -Xms512m -Xmx512m; FESS_HEAP_SIZE=768m still yields -Xms768m
-Xmx768m and keeps winning when the pair is set alongside it; and half a
pair falls back to the Fess default for the other half. Adding an explicit
export of the pair to run.sh changes none of these results, which is why
the run.sh side is the sed alone. The claim about exporting the variable was
confirmed by exporting it on the host and reading an empty value inside the
container.

Applied to the snapshot variants only, since the released images are
already published and are not rebuilt.
