### PR TITLE
docs: make the quick start runnable and fill in the gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,38 +46,47 @@ echo 'vm.max_map_count=262144' | sudo tee -a /etc/sysctl.conf
 
 ### Standard Deployment
 
+The Compose files live in the `compose/` directory, so clone the repository and move there first. The commands that follow assume that working directory unless they change it themselves.
+
 ```bash
 # Clone the repository
 git clone https://github.com/codelibs/docker-fess.git
-cd docker-fess
+cd docker-fess/compose
 
 # Start Fess with OpenSearch
 docker compose -f compose.yaml -f compose-opensearch3.yaml up -d
-
-# Access Fess web interface
-open http://localhost:8080
 ```
+
+Fess is then available at http://localhost:8080.
 
 ### With OpenSearch Dashboards
 
 ```bash
-# Start with visualization dashboard
 docker compose -f compose.yaml -f compose-opensearch3.yaml -f compose-dashboards3.yaml up -d
-
-# Access services
-open http://localhost:8080  # Fess
-open http://localhost:5601  # OpenSearch Dashboards
 ```
+
+Fess is at http://localhost:8080 and OpenSearch Dashboards at http://localhost:5601.
 
 ### With Object Storage (MinIO)
 
 ```bash
-# Start with MinIO for file storage
 docker compose -f compose.yaml -f compose-opensearch3.yaml -f compose-minio.yaml up -d
+```
 
-# Access services
-open http://localhost:8080  # Fess
-open http://localhost:9001  # MinIO Console
+Fess is at http://localhost:8080 and the MinIO console at http://localhost:9001.
+
+### Development Snapshots
+
+The snapshot stack runs the in-development Fess build. `compose/snapshot/compose.yaml` only defines the Fess service, so it has to be combined with a backend, exactly like `compose.yaml`:
+
+```bash
+cd docker-fess/compose/snapshot
+
+# Single OpenSearch node
+docker compose -f compose.yaml -f ../compose-opensearch3.yaml up -d
+
+# Five-node OpenSearch cluster
+docker compose -f compose.yaml -f compose-cluster.yaml up -d
 ```
 
 ## Usage
@@ -115,8 +124,27 @@ environment:
   - FESS_JAVA_OPTS=-Djavax.net.ssl.trustStore=/opt/fess/truststore.jks
 
   # Plugin installation
-  - FESS_PLUGINS=fess-webapp-semantic-search:15.8.0 fess-ds-wikipedia:15.8.0
+  - FESS_PLUGINS=fess-ds-wikipedia:15.8.0 fess-ds-git:15.8.0
 ```
+
+The full set the images understand:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SEARCH_ENGINE_HTTP_URL` | `http://localhost:9200` | Backend search engine URL |
+| `FESS_DICTIONARY_PATH` | `/var/lib/opensearch/config/` | Dictionary directory shared with OpenSearch |
+| `FESS_PORT` | `8080` | Port Fess listens on inside the container |
+| `FESS_CONTEXT_PATH` | `/` | Context path Fess is served under, e.g. `/fess` |
+| `FESS_HEAP_SIZE` | `512m` | Heap size; see Memory Settings below |
+| `FESS_MIN_MEM` / `FESS_MAX_MEM` | (none) | Asymmetric heap bounds; see Memory Settings below |
+| `FESS_JAVA_OPTS` | (none) | Extra JVM options, mainly `-Dfess.config.*` and `-Dfess.system.*` |
+| `FESS_PLUGINS` | (none) | Space-separated `plugin-name:version` list to install at startup |
+| `FESS_CONF_PATH` | `/etc/fess` | Configuration directory |
+| `FESS_OVERRIDE_CONF_PATH` | `/opt/fess` | Extra configuration directory placed ahead of `FESS_CONF_PATH` on the classpath, so a file mounted here replaces the packaged one |
+| `PING_INTERVAL` | `60` | Seconds between the entrypoint's health probes |
+| `PING_RETRIES` | `3` | Consecutive failed probes before the entrypoint gives up and the container exits |
+
+The health check builds its URL from `FESS_PORT` and `FESS_CONTEXT_PATH`, so moving Fess to another port or context path does not make the container report unhealthy.
 
 #### Memory Settings
 
@@ -138,17 +166,13 @@ Do not pass `-Xms` or `-Xmx` through `FESS_JAVA_OPTS`. Fess appends the pair it 
 Run multiple Fess instances sharing one OpenSearch cluster:
 
 ```bash
-cd compose/multi-instance
+cd docker-fess/compose/multi-instance
 
 # Start OpenSearch + 2 Fess instances
 docker compose -f compose.yaml -f compose-fess01.yaml -f compose-fess02.yaml up -d
-
-# Access instances
-open http://localhost:8080  # Fess instance 1
-open http://localhost:8081  # Fess instance 2
 ```
 
-Each instance uses separate indices for data isolation.
+Instance 1 is at http://localhost:8080 and instance 2 at http://localhost:8081. Each instance uses separate indices for data isolation.
 
 ### Service URLs
 
@@ -196,7 +220,9 @@ docker-fess/
     ├── compose-opensearch3.yaml  # OpenSearch 3.x
     ├── compose-dashboards3.yaml  # OpenSearch Dashboards
     ├── compose-minio.yaml  # MinIO object storage
-    └── multi-instance/     # Multi-instance setup
+    ├── multi-instance/     # Multi-instance setup
+    ├── snapshot/           # Development snapshot builds
+    └── vanilla/            # Stock OpenSearch, without the Fess plugins
 ```
 
 ### Configuration Files
@@ -219,6 +245,7 @@ FESS_JAVA_OPTS="-Dfess.config.index.document.search.index=myapp.search \
 
 | Fess Version | OpenSearch | Elasticsearch | Java | Base Image |
 |--------------|------------|---------------|------|------------|
+| 15.9.0-SNAPSHOT (`snapshot` tag) | 3.8.0 | - | 21 | Alpine/Ubuntu Noble/Amazon Linux 2023 |
 | 15.8.0 | 3.8.0 | - | 21 | Alpine/Ubuntu Noble/Amazon Linux 2023 |
 | 15.7.0 | 3.7.0 | - | 21 | Alpine/Ubuntu Noble/Amazon Linux 2023 |
 | 15.6.0 | 3.6.0 | - | 21 | Alpine/Ubuntu Noble/Amazon Linux 2023 |
@@ -299,21 +326,29 @@ Install additional Fess plugins:
 
 ```yaml
 environment:
-  - FESS_PLUGINS=fess-webapp-semantic-search:15.8.0 fess-ds-wikipedia:15.8.0
+  - FESS_PLUGINS=fess-ds-wikipedia:15.8.0 fess-ds-git:15.8.0
 ```
 
-### SSL/TLS Configuration
+Entries are `plugin-name:version` pairs separated by spaces, and the name has to start with one of `fess-ds-`, `fess-ingest-`, `fess-llm-`, `fess-script-`, `fess-theme-` or `fess-webapp-`. A name that is not recognized, or a version that cannot be downloaded, is skipped and does not stop the container from starting, so check the boot log after adding a plugin.
 
-Configure HTTPS for production:
+Semantic search no longer needs a plugin. It became part of Fess in 15.8, and `fess-webapp-semantic-search` is not published for 15.8 or later.
 
-```bash
-# Mount certificate volumes
-volumes:
-  - ./certs/keystore.jks:/usr/share/fess/keystore.jks:ro
-  
-environment:
-  - FESS_JAVA_OPTS=-Dserver.ssl.key-store=/usr/share/fess/keystore.jks
+### Running Behind a Reverse Proxy
+
+When TLS is terminated at a proxy in front of Fess, the container still speaks plain HTTP, and two settings have to be told about the public origin.
+
+```yaml
+services:
+  fess01:
+    environment:
+      - "FESS_JAVA_OPTS=-Dfess.config.session.cookie.secure=true -Dfess.config.theme.api.csrf.server.origins=https://fess.example.com"
 ```
+
+`session.cookie.secure` ships blank, which leaves the `Secure` attribute to Tomcat, and Tomcat only adds it when the request it sees is HTTPS. Behind a TLS-terminating proxy that request is HTTP, so `JSESSIONID` goes out without `Secure` unless this is set to `true`. Keep it blank for plain-HTTP development, because the browser will not send the cookie back over HTTP once it is set.
+
+`theme.api.csrf.server.origins` is the list of origins the v2 API treats as its own. It also ships blank, and the API then reconstructs the expected origin from the request, which does not match the proxy's public origin. `POST /api/v2/login` through a proxy is rejected with `cross-site request blocked` until the public origin is listed here.
+
+Fess has no key store option of its own, so terminate TLS at the proxy rather than in the container.
 
 ### Backup and Recovery
 

--- a/compose/README.md
+++ b/compose/README.md
@@ -21,6 +21,14 @@ For Linux users, please see [Installing Compose V2](https://docs.docker.com/comp
 | `compose-gemini.yaml` | Google Gemini LLM (cloud API) for AI/RAG Chat |
 | `compose-openai.yaml` | OpenAI LLM (cloud API) for AI/RAG Chat |
 
+Three further stacks live in their own directories and are run from there:
+
+| Directory | Description |
+|-----------|-------------|
+| `snapshot/` | The in-development Fess build (`compose.yaml` plus a backend, or `compose-cluster.yaml` for five OpenSearch nodes) |
+| `multi-instance/` | Several Fess instances over one OpenSearch cluster |
+| `vanilla/` | Stock OpenSearch without the Fess plugins |
+
 ## Usage
 
 ### Fess with OpenSearch
@@ -76,6 +84,17 @@ docker compose -f compose.yaml -f compose-opensearch3.yaml -f compose-openai.yam
 The OpenAI overlay installs the `fess-llm-openai` plugin via `FESS_PLUGINS`,
 sets `rag.chat.enabled=true` and `rag.llm.name=openai`, and forwards the API key.
 Override the model with `OPENAI_MODEL` (default: `gpt-5-mini`).
+
+### Fess Snapshot Builds
+
+`snapshot/compose.yaml` defines only the Fess service, exactly like `compose.yaml`, so it has to be combined with a backend. Run it from `snapshot/`:
+
+```bash
+cd snapshot
+docker compose -f compose.yaml -f ../compose-opensearch3.yaml up -d
+```
+
+Use `compose-cluster.yaml` instead of `../compose-opensearch3.yaml` for a five-node OpenSearch cluster.
 
 ### Tips: Using a Local Directory for Ollama Model Data
 

--- a/compose/compose.yaml
+++ b/compose/compose.yaml
@@ -6,7 +6,7 @@ services:
     environment:
       - "SEARCH_ENGINE_HTTP_URL=http://search01:9200"
       - "FESS_DICTIONARY_PATH=${FESS_DICTIONARY_PATH:-/usr/share/opensearch/config/dictionary/}"
-      # - "FESS_PLUGINS=fess-webapp-semantic-search:15.8.0 fess-ds-wikipedia:15.8.0"
+      # - "FESS_PLUGINS=fess-ds-wikipedia:15.8.0 fess-ds-git:15.8.0"
     ports:
       - "8080:8080"
     networks:

--- a/compose/vanilla/compose.yaml
+++ b/compose/vanilla/compose.yaml
@@ -8,7 +8,7 @@ services:
       - "SEARCH_ENGINE_HTTP_URL=http://search01:9200"
       - "SEARCH_ENGINE_TYPE=cloud"
       - "FESS_DICTIONARY_PATH=${FESS_DICTIONARY_PATH:-/usr/share/opensearch/config/dictionary/}"
-      # - "FESS_PLUGINS=fess-webapp-semantic-search:15.8.0 fess-ds-wikipedia:15.8.0"
+      # - "FESS_PLUGINS=fess-ds-wikipedia:15.8.0 fess-ds-git:15.8.0"
     ports:
       - "8080:8080"
     networks:


### PR DESCRIPTION
Neither compose command a reader is likely to try actually worked. The
Compose files live under compose/, so the quick start's
"docker compose -f compose.yaml -f compose-opensearch3.yaml up -d" after
"cd docker-fess" fails with "no such file or directory", and
compose/snapshot/compose.yaml defines only the Fess service, so running it
on its own fails with 'service "fess01" depends on undefined service
"search01"'. Point the clone at docker-fess/compose, and give the snapshot
stack a section of its own that pairs it with a backend, either the single
node from compose-opensearch3.yaml or the five in compose-cluster.yaml.

Add a row for the 15.9.0-SNAPSHOT line to the version matrix, which stopped
at 15.8.0 although the snapshot images moved on some time ago. 15.9.0 is
not released, so the row names the snapshot tag rather than a version that
cannot be pulled.

Correct the plugin examples. fess-webapp-semantic-search:15.8.0 appears in
the README and in two Compose files and it 404s: semantic search became
part of Fess in 15.8 and the plugin is no longer published. Use two plugins
that do exist, and state the accepted name format and the fact that a name
or version Fess cannot resolve is skipped without stopping startup.

Write down the settings that already work and were never documented:
FESS_PORT, FESS_CONTEXT_PATH, FESS_CONF_PATH, FESS_OVERRIDE_CONF_PATH,
PING_INTERVAL and PING_RETRIES now appear in a table with the rest.

Replace the SSL/TLS section. It told readers to set -Dserver.ssl.key-store,
a key that appears nowhere in Fess, so the advice could never have worked.
Fess has no key store option of its own, and the realistic deployment
terminates TLS at a proxy, which needs two settings the defaults do not
cover: session.cookie.secure, because Tomcat adds the Secure attribute only
when the request it sees is HTTPS and behind a terminating proxy it is not,
and theme.api.csrf.server.origins, because the v2 API otherwise rebuilds
the expected origin from the request and refuses POST /api/v2/login with
"cross-site request blocked".

Every command added or changed here was run. The clone followed by
"cd docker-fess/compose" lands on the two files the next command names, and
the standard stack, the snapshot stack on a single node, the snapshot stack
on the five-node cluster and the two-instance stack each came up and
answered 200 on /api/v2/health, with the cluster reaching green across five
nodes and the two instances writing to separate index sets. The dashboards
and MinIO overlays were checked with "docker compose config" only, since
their invocation is unchanged. Host ports and container names were remapped
through an extra local overlay so the run would not collide with other work
on the same machine; nothing else about the commands was altered.

The reverse proxy settings were confirmed against a running container. With
the defaults, JSESSIONID comes back as "Path=/; HttpOnly; SameSite=Lax"
with no Secure attribute, and a login carrying a proxy-style Origin is
refused with "cross-site request blocked". With the two options set, the
cookie gains Secure and the same login gets past the origin check, while a
login from a different Origin is still refused.

The multi-instance files stay pinned to 15.8.0, which is the current
release; 15.9.0 has no published artifacts to point them at.

