### PR TITLE
fix(fess): keep the container up while Fess is still starting

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,14 @@ The full set the images understand:
 | `FESS_CONF_PATH` | `/etc/fess` | Configuration directory |
 | `FESS_OVERRIDE_CONF_PATH` | `/opt/fess` | Extra configuration directory placed ahead of `FESS_CONF_PATH` on the classpath, so a file mounted here replaces the packaged one |
 | `PING_INTERVAL` | `60` | Seconds between the entrypoint's health probes |
-| `PING_RETRIES` | `3` | Consecutive failed probes before the entrypoint gives up and the container exits |
+| `PING_RETRIES` | `5` | Consecutive failed probes, once Fess has answered at least once, before the entrypoint gives up and the container exits |
+| `PING_STARTUP_RETRIES` | `10` | Failed probes allowed before Fess has answered for the first time |
 
 The health check builds its URL from `FESS_PORT` and `FESS_CONTEXT_PATH`, so moving Fess to another port or context path does not make the container report unhealthy.
+
+Startup is counted separately from an outage. Fess has not answered yet while it is still starting, and on a loaded host that takes longer than a running instance ever goes unanswered; counting those probes against `PING_RETRIES` used to kill a container that was only slow to come up. With the defaults, Fess has ten minutes to answer for the first time, and five consecutive failed probes after that end the container.
+
+`FESS_JAVA_OPTS` is split on whitespace, so an option whose value contains a space breaks the JVM command line: the container fails with `Could not find or load main class` and then exits. Options with such a value belong in `/opt/fess/fess_config.properties` (see `FESS_OVERRIDE_CONF_PATH`) instead.
 
 #### Memory Settings
 

--- a/compose/README.md
+++ b/compose/README.md
@@ -27,7 +27,7 @@ Three further stacks live in their own directories and are run from there:
 |-----------|-------------|
 | `snapshot/` | The in-development Fess build (`compose.yaml` plus a backend, or `compose-cluster.yaml` for five OpenSearch nodes) |
 | `multi-instance/` | Several Fess instances over one OpenSearch cluster |
-| `vanilla/` | Stock OpenSearch without the Fess plugins |
+| `vanilla/` | Stock OpenSearch without the Fess plugins (`compose.yaml` plus `compose-opensearch3.yaml`) |
 
 ## Usage
 

--- a/fess/snapshot-al2023/run.sh
+++ b/fess/snapshot-al2023/run.sh
@@ -61,7 +61,15 @@ if [[ "x${FESS_JAVA_OPTS}" != "x" ]] ; then
 fi
 
 if [[ "x${PING_RETRIES}" = "x" ]] ; then
-  PING_RETRIES=3
+  PING_RETRIES=5
+fi
+
+# Fess has not answered yet while it is still starting, and on a loaded host that
+# takes longer than a running instance ever goes unanswered. Counting those
+# probes against PING_RETRIES let the supervisor kill a container that was only
+# slow to come up.
+if [[ "x${PING_STARTUP_RETRIES}" = "x" ]] ; then
+  PING_STARTUP_RETRIES=10
 fi
 
 if [[ "x${PING_INTERVAL}" = "x" ]] ; then
@@ -145,16 +153,28 @@ wait_app() {
   # follows a relocated port or context path. A bare "/" context path is the
   # Fess default and must not become a double slash.
   ping_url="http://localhost:${FESS_PORT:-8080}${FESS_CONTEXT_PATH%/}/api/v2/health"
+  error_count=0
+  started=false
   while true ; do
     status=$(curl -w '%{http_code}\n' -s -o /dev/null "${ping_url}")
     if [[ x"${status}" = x200 ]] ; then
+      started=true
       error_count=0
     else
       error_count=$((error_count + 1))
-    fi
-    if [[ ${error_count} -ge ${PING_RETRIES} ]] ; then
-      print_log ERROR "Fess is not available."
-      exit 1
+      if [[ "${started}" = "true" ]] ; then
+        retries=${PING_RETRIES}
+      else
+        retries=${PING_STARTUP_RETRIES}
+      fi
+      if [[ ${error_count} -ge ${retries} ]] ; then
+        if [[ "${started}" = "true" ]] ; then
+          print_log ERROR "Fess is not available."
+        else
+          print_log ERROR "Fess did not start within ${PING_STARTUP_RETRIES} health probes."
+        fi
+        exit 1
+      fi
     fi
     sleep ${PING_INTERVAL}
   done

--- a/fess/snapshot-noble/run.sh
+++ b/fess/snapshot-noble/run.sh
@@ -61,7 +61,15 @@ if [[ "x${FESS_JAVA_OPTS}" != "x" ]] ; then
 fi
 
 if [[ "x${PING_RETRIES}" = "x" ]] ; then
-  PING_RETRIES=3
+  PING_RETRIES=5
+fi
+
+# Fess has not answered yet while it is still starting, and on a loaded host that
+# takes longer than a running instance ever goes unanswered. Counting those
+# probes against PING_RETRIES let the supervisor kill a container that was only
+# slow to come up.
+if [[ "x${PING_STARTUP_RETRIES}" = "x" ]] ; then
+  PING_STARTUP_RETRIES=10
 fi
 
 if [[ "x${PING_INTERVAL}" = "x" ]] ; then
@@ -144,16 +152,28 @@ wait_app() {
   # follows a relocated port or context path. A bare "/" context path is the
   # Fess default and must not become a double slash.
   ping_url="http://localhost:${FESS_PORT:-8080}${FESS_CONTEXT_PATH%/}/api/v2/health"
+  error_count=0
+  started=false
   while true ; do
     status=$(curl -w '%{http_code}\n' -s -o /dev/null "${ping_url}")
     if [[ x"${status}" = x200 ]] ; then
+      started=true
       error_count=0
     else
       error_count=$((error_count + 1))
-    fi
-    if [[ ${error_count} -ge ${PING_RETRIES} ]] ; then
-      print_log ERROR "Fess is not available."
-      exit 1
+      if [[ "${started}" = "true" ]] ; then
+        retries=${PING_RETRIES}
+      else
+        retries=${PING_STARTUP_RETRIES}
+      fi
+      if [[ ${error_count} -ge ${retries} ]] ; then
+        if [[ "${started}" = "true" ]] ; then
+          print_log ERROR "Fess is not available."
+        else
+          print_log ERROR "Fess did not start within ${PING_STARTUP_RETRIES} health probes."
+        fi
+        exit 1
+      fi
     fi
     sleep ${PING_INTERVAL}
   done

--- a/fess/snapshot/run.sh
+++ b/fess/snapshot/run.sh
@@ -52,7 +52,15 @@ fi
 export FESS_JAVA_OPTS
 
 if [[ "x${PING_RETRIES}" = "x" ]] ; then
-  PING_RETRIES=3
+  PING_RETRIES=5
+fi
+
+# Fess has not answered yet while it is still starting, and on a loaded host that
+# takes longer than a running instance ever goes unanswered. Counting those
+# probes against PING_RETRIES let the supervisor kill a container that was only
+# slow to come up.
+if [[ "x${PING_STARTUP_RETRIES}" = "x" ]] ; then
+  PING_STARTUP_RETRIES=10
 fi
 
 if [[ "x${PING_INTERVAL}" = "x" ]] ; then
@@ -136,16 +144,28 @@ wait_app() {
   # follows a relocated port or context path. A bare "/" context path is the
   # Fess default and must not become a double slash.
   ping_url="http://localhost:${FESS_PORT:-8080}${FESS_CONTEXT_PATH%/}/api/v2/health"
+  error_count=0
+  started=false
   while true ; do
     status=$(curl -w '%{http_code}\n' -s -o /dev/null "${ping_url}")
     if [[ x"${status}" = x200 ]] ; then
+      started=true
       error_count=0
     else
       error_count=$((error_count + 1))
-    fi
-    if [[ ${error_count} -ge ${PING_RETRIES} ]] ; then
-      print_log ERROR "Fess is not available."
-      exit 1
+      if [[ "${started}" = "true" ]] ; then
+        retries=${PING_RETRIES}
+      else
+        retries=${PING_STARTUP_RETRIES}
+      fi
+      if [[ ${error_count} -ge ${retries} ]] ; then
+        if [[ "${started}" = "true" ]] ; then
+          print_log ERROR "Fess is not available."
+        else
+          print_log ERROR "Fess did not start within ${PING_STARTUP_RETRIES} health probes."
+        fi
+        exit 1
+      fi
     fi
     sleep ${PING_INTERVAL}
   done


### PR DESCRIPTION
The entrypoint's supervisor loop cannot tell a Fess that has not started yet
from one that has stopped answering, and it counted both against PING_RETRIES:
three failed probes a minute apart, so a container that took longer than two
minutes to come up was killed by its own supervisor and restarted, over and
over. Starting eleven containers on one host reproduced it every time.

Startup is now counted separately. PING_STARTUP_RETRIES probes are allowed
until Fess answers for the first time, and PING_RETRIES after that -- raised
from 3 to 5, because a backend that is restarting is regularly away for longer
than two minutes and that is not a reason to end the container.

The README gains the new variable and the reason startup is counted separately,
plus a note that FESS_JAVA_OPTS is split on whitespace: an option whose value
contains a space breaks the JVM command line and the container exits with
"Could not find or load main class". The compose README says which backend file
the vanilla stack has to be combined with, which it stated for every other
stack already.

---

**Not included, deliberately.** The verification also noted that `fess-urls.log` and
`searchlog.log` never reach `docker logs`. They are left out of the `tail` list on purpose:
the container's console has to stay one JSON object per line. The Dockerfile uncomments the
`EcsLayout` in every `log4j2.xml` it ships, so the logs that are followed are written as JSON,
while `searchlog.log` (`%msg%n`) and `fess-urls.log` (the crawler's `StatsFile`) keep a plain
`PatternLayout`. Adding them would put non-JSON lines into that stream. Both remain readable
with `docker exec`.
